### PR TITLE
firewall.ycp - move the include statement to the top

### DIFF
--- a/src/firewall.ycp
+++ b/src/firewall.ycp
@@ -40,6 +40,8 @@ you may find current contact information at www.novell.com
     import "SuSEFirewall";
     import "Mode";
 
+    include "firewall/wizards.ycp";
+
     any ret = nil;
 
     // bnc #388773
@@ -53,7 +55,6 @@ you may find current contact information at www.novell.com
 	SuSEFirewallCMDLine::Run();
     // GUI or TextUI
     } else {
-	include "firewall/wizards.ycp";
 	// installation has other sequence
 	if (Mode::installation()) {
 	    ret = FirewallInstallationSequence();


### PR DESCRIPTION
Ycp to Ruby translation (y2r) does not support non-toplevel includes
