### PR TITLE
Merge firewall configuration instead of overwriting it

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb  4 16:47:22 UTC 2016 - igonzalezsosa@suse.com
+
+- When importing firewall settings from an AutoYaST profile,
+  they're merged with the current system's configuration
+  (related with bnc#963585)
+- 3.1.1.2
+
+-------------------------------------------------------------------
 Fri Nov 13 09:15:40 UTC 2015 - igonzalezsosa@suse.com
 
 - fix validation of AutoYaST profiles (bnc#954412)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        3.1.1.1
+Version:        3.1.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firewall_auto.rb
+++ b/src/clients/firewall_auto.rb
@@ -87,9 +87,7 @@ module Yast
         SuSEFirewall.SetStartService(SuSEFirewall.GetEnableService)
       # Import configuration
       elsif @func == "Import"
-        @ret = SuSEFirewall.Import(
-          Convert.convert(@param, :from => "map", :to => "map <string, any>")
-        )
+        @ret = SuSEFirewall.read_and_import(@param)
       # Read firewall data
       elsif @func == "Read"
         @ret = SuSEFirewall.Read

--- a/test/clients/firewall_auto_test.rb
+++ b/test/clients/firewall_auto_test.rb
@@ -1,0 +1,113 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require_relative "../../src/clients/firewall_auto.rb"
+
+Yast.import "SuSEFirewall"
+
+describe Yast::FirewallAutoClient do
+  describe "#main" do
+    before do
+      allow(Yast::WFM).to receive(:Args) do |n|
+        n.nil? ? args : args[n]
+      end
+    end
+
+    describe "summary action" do
+      let(:args) { ["Summary"] }
+
+      it "shows firewall zones" do
+        allow(Yast::SuSEFirewall).to receive(:GetKnownFirewallZones)
+          .and_return([])
+        expect(subject).to receive(:InitBoxSummary).with([])
+          .and_return("Some summary")
+        expect(subject.main).to eq("Some summary")
+      end
+    end
+
+    describe "Reset" do
+      let(:args) { ["Reset"] }
+
+      it "empties the firewall configuration and disables it" do
+        expect(Yast::SuSEFirewall).to receive(:Import).with({})
+        expect(Yast::SuSEFirewall).to receive(:SetEnableService).with(false)
+        expect(subject.main).to eq({})
+      end
+    end
+
+    describe "Packages" do
+      let(:args) { ["Packages"] }
+
+      it "returns SuSEfirewall2 package" do
+        expect(subject.main).to eq("install" => ["SuSEfirewall2"])
+      end
+    end
+
+    describe "Change" do
+      let(:args) { ["Change"] }
+
+      it "runs wizard, set 'start' value and returns wizard's result" do
+        expect(subject).to receive(:FirewallAutoSequence).and_return(:some_value)
+        expect(Yast::SuSEFirewall).to receive(:GetEnableService).and_return(false)
+        expect(Yast::SuSEFirewall).to receive(:SetStartService).with(false)
+        expect(subject.main).to eq(:some_value)
+      end
+    end
+
+    describe "Import" do
+      let(:args) { ["Import", config] }
+      let(:config) { { "start_firewall" => true } }
+
+      it "imports configuration and returns nil" do
+        expect(Yast::SuSEFirewall).to receive(:Import).with(config).and_return(nil)
+        expect(subject.main).to be_nil
+      end
+    end
+
+    describe "Read" do
+      let(:args) { ["Read"] }
+
+      it "reads firewall configuration and returns operation's result" do
+        expect(Yast::SuSEFirewall).to receive(:Read).and_return(:some_result)
+        expect(subject.main).to eq(:some_result)
+      end
+    end
+
+    describe "Export" do
+      let(:args) { ["Export"] }
+      let(:config) { { "start_firewall" => true } }
+
+      it "returns firewall configuration" do
+        expect(Yast::SuSEFirewall).to receive(:Export).and_return(config)
+        expect(subject.main).to eq(config)
+      end
+    end
+
+    describe "GetModified" do
+      let(:args) { ["GetModified"] }
+
+      it "checks whether the configuration was modified or not" do
+        expect(Yast::SuSEFirewall).to receive(:GetModified).and_return(true)
+        expect(subject.main).to eq(true)
+      end
+    end
+
+    describe "SetModified" do
+      let(:args) { ["SetModified"] }
+
+      it "marks configuration as modified and returns true" do
+        expect(Yast::SuSEFirewall).to receive(:SetModified)
+        expect(subject.main).to eq(true)
+      end
+    end
+
+    describe "Write" do
+      let(:args) { ["Write"] }
+
+      it "writes firewall configuration and returns operation's result" do
+        expect(Yast::SuSEFirewall).to receive(:Write).and_return(:some_result)
+        expect(subject.main).to eq(:some_result)
+      end
+    end
+  end
+end

--- a/test/clients/firewall_auto_test.rb
+++ b/test/clients/firewall_auto_test.rb
@@ -59,7 +59,7 @@ describe Yast::FirewallAutoClient do
       let(:config) { { "start_firewall" => true } }
 
       it "imports configuration and returns nil" do
-        expect(Yast::SuSEFirewall).to receive(:Import).with(config).and_return(nil)
+        expect(Yast::SuSEFirewall).to receive(:read_and_import).with(config).and_return(nil)
         expect(subject.main).to be_nil
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,43 @@
+# Copyright (c) 2016 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+# Set the paths
+src_path = File.expand_path("../../src", __FILE__)
+ENV["Y2DIR"] = src_path
+
+require "yast"
+require "yast/rspec"
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  # for coverage we need to load all ruby files
+  Dir["#{src_path}/{modules,lib}/**/*.rb"].each { |f| require_relative f }
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end


### PR DESCRIPTION
When using an AutoYaST profile, it merges firewall configuration instead of overwriting it. Second part of https://github.com/yast/yast-yast2/pull/436.