### PR TITLE
Revert config merge

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,12 +1,4 @@
 -------------------------------------------------------------------
-Thu Feb  4 16:47:22 UTC 2016 - igonzalezsosa@suse.com
-
-- When importing firewall settings from an AutoYaST profile,
-  they're merged with the current system's configuration
-  (related with bnc#963585)
-- 3.1.1.2
-
--------------------------------------------------------------------
 Fri Nov 13 09:15:40 UTC 2015 - igonzalezsosa@suse.com
 
 - fix validation of AutoYaST profiles (bnc#954412)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        3.1.1.2
+Version:        3.1.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firewall_auto.rb
+++ b/src/clients/firewall_auto.rb
@@ -87,7 +87,9 @@ module Yast
         SuSEFirewall.SetStartService(SuSEFirewall.GetEnableService)
       # Import configuration
       elsif @func == "Import"
-        @ret = SuSEFirewall.read_and_import(@param)
+        @ret = SuSEFirewall.Import(
+          Convert.convert(@param, :from => "map", :to => "map <string, any>")
+        )
       # Read firewall data
       elsif @func == "Read"
         @ret = SuSEFirewall.Read

--- a/test/clients/firewall_auto_test.rb
+++ b/test/clients/firewall_auto_test.rb
@@ -59,7 +59,7 @@ describe Yast::FirewallAutoClient do
       let(:config) { { "start_firewall" => true } }
 
       it "imports configuration and returns nil" do
-        expect(Yast::SuSEFirewall).to receive(:read_and_import).with(config).and_return(nil)
+        expect(Yast::SuSEFirewall).to receive(:Import).with(config).and_return(nil)
         expect(subject.main).to be_nil
       end
     end


### PR DESCRIPTION
Revert firewall configuration merge. As pointed by @jreidinger, we should modify SuSEFirewall.Import instead of using a new method. It was done in this way because we feared someone was using that method. But it can be confusing.