### PR TITLE
FirewallD support

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May 24 15:26:37 UTC 2016 - mchandras@suse.de
+
+- Add support for firewalld (fate#318356)
+  * Bump yast2 dependency to 3.1.191 which is the first version to
+    support the firewalld backend.
+- 3.1.5
+
+-------------------------------------------------------------------
 Fri Nov 13 09:15:40 UTC 2015 - igonzalezsosa@suse.com
 
 - fix validation of AutoYaST profiles (bnc#954412)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        3.1.4
+Version:        3.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -30,8 +30,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 # IP::CheckNetwork
 BuildRequires:	yast2 >= 2.23.25
 
-# IP::CheckNetwork
-Requires:	yast2 >= 2.23.25
+# FirewallD backend
+Requires:	yast2 >= 3.1.191
 
 # ButtonBox widget
 Conflicts:	yast2-ycp-ui-bindings < 2.17.3

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -1645,7 +1645,7 @@ module Yast
       return unless firewalld?
 
       # Actions not supported by FirewallD
-      firewalld_disabled = ["broadcast"]
+      firewalld_disabled = ["broadcast", "masqredirect"]
 
       firewalld_disabled.each do |opt|
         @cmdline["actions"].delete(opt)

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -377,6 +377,9 @@ module Yast
           "disable"      => []
         }
       }
+
+      ConfigureFirewalld()
+
     end
 
     # Returns list of strings made from the comma-separated string got as param.
@@ -1603,6 +1606,19 @@ module Yast
     # Returns true if FirewallD is the running backend
     def firewalld?
       SuSEFirewall.is_a?(Yast::SuSEFirewalldClass)
+    end
+
+    def ConfigureFirewalld
+      return unless firewalld?
+
+      # Actions not supported by FirewallD
+      firewalld_disabled = []
+
+      firewalld_disabled.each do |opt|
+        @cmdline["actions"].delete(opt)
+        @cmdline["mappings"].delete(opt)
+      end
+
     end
 
     publish :function => :Run, :type => "void ()"

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -1655,6 +1655,16 @@ module Yast
       @cmdline["actions"]["masquerade"]["example"] << "masquerade zone=public enable"
       @cmdline["mappings"]["masquerade"] <<  "zone"
 
+      # protection from internal zone does not apply to FirewallD
+      @cmdline["actions"]["services"]["example"] = [
+        "services show detailed",
+        "services add service=service:dhcp-server zone=EXT",
+        "services remove ipprotocol=esp tcpport=12,13,ipp zone=DMZ"
+      ]
+      # Remove unsupported options for FirewallD
+      @cmdline["mappings"]["services"].delete("rpcport")
+      @cmdline["mappings"]["services"].delete("protect")
+
     end
 
     publish :function => :Run, :type => "void ()"

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -1612,7 +1612,7 @@ module Yast
       return unless firewalld?
 
       # Actions not supported by FirewallD
-      firewalld_disabled = []
+      firewalld_disabled = ["broadcast"]
 
       firewalld_disabled.each do |opt|
         @cmdline["actions"].delete(opt)

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -30,6 +30,7 @@
 #
 # $Id$
 require "yast"
+require "network/susefirewalld"
 
 module Yast
   class SuSEFirewallCMDLineClass < Module
@@ -1597,6 +1598,12 @@ module Yast
       Builtins.y2milestone("----------------------------------------")
 
       nil
+    end
+
+  private
+    # Returns true if FirewallD is the running backend
+    def firewalld?
+      SuSEFirewall.is_a?(Yast::SuSEFirewalldClass)
     end
 
     publish :function => :Run, :type => "void ()"

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -490,7 +490,17 @@ module Yast
       # TRANSLATORS: CommandLine header
       CommandLine.Print(String.UnderlinedHeader(_("Summary:"), 0))
       CommandLine.Print("")
-      CommandLine.Print(InitBoxSummary(for_zones))
+      if firewalld?
+        if for_zones.empty?
+          CommandLine.Print(SuSEFirewall.fwd_api.list_all_zones.join("\n"))
+        else
+          for_zones.each do |zone|
+            CommandLine.Print(SuSEFirewall.fwd_api.list_all_zone(zone).join("\n"))
+          end
+        end
+      else
+        CommandLine.Print(InitBoxSummary(for_zones))
+      end
 
       # Do not call Write()
       false

--- a/src/modules/SuSEFirewallCMDLine.rb
+++ b/src/modules/SuSEFirewallCMDLine.rb
@@ -567,7 +567,6 @@ module Yast
         CommandLine.Print("")
 
         table_items = []
-        special_interfaces = {}
         Builtins.foreach(SuSEFirewall.GetKnownFirewallZones) do |zone|
           # for_zone defined but it is not current zone
           next if for_zone != nil && for_zone != zone


### PR DESCRIPTION
Hi,

This completes the firewalld support in Yast2 (https://github.com/yast/yast-yast2/pull/471, https://github.com/yast/yast-yast2/pull/457) by adding support for this backend in the yast-firewall module. This patchset uses the upstream firewall-config UI instead of the one in the module. This is because I believe it's more beneficial to use what upstream provides instead of designing our own. However, since the SF2 and FirewallD APIs are (almost) compatible, it's should be possible to use the existing one without too much effort. However, using the upstream one means that no ncurses support is provided. Those who prefer to configure Yast2 from their terminal, it's possible to use the Yast2 command line interface, or better yet, use the upstream ```firewall-cmd``` tool.