### PR TITLE
Temporal fix for auto installation and firewalld defaults.

### DIFF
--- a/src/clients/firewall_auto.rb
+++ b/src/clients/firewall_auto.rb
@@ -77,7 +77,7 @@ module Yast
       elsif @func == "Reset"
         SuSEFirewall.Import({})
         @ret = {}
-        SuSEFirewall.SetEnableService(SuSEFirewall.GetStartService)
+        SuSEFirewall.SetEnableService(SuSEFirewall.GetStartService || false)
       # Return required packages for module to operate
       elsif @func == "Packages"
         @ret = { "install" => [ "SuSEfirewall2" ] }


### PR DESCRIPTION
- With firewalld the default without Read is nil. This is a temporal for workaround for #33 as we will drop SuSEFirewall.

