### PR TITLE
Disable ssh port (bsc#1068354)

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Nov 21 00:15:55 UTC 2017 - knut.anderssen@suse.com
+
+- Proposal: When the Firewall is disabled, open/close port links
+  are not shown in the proposal and are disabled in the specific
+  proposal dialog (bsc#1068354).
+- 4.0.5
+
+-------------------------------------------------------------------
 Wed Nov 15 14:11:40 UTC 2017 - knut.anderssen@suse.com
 
 - Do not touch firewalld services if it is not enabled in the

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -28,7 +28,7 @@ License:        GPL-2.0
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 3.1.10
 # IP::CheckNetwork
-BuildRequires:	yast2 >= 2.23.25
+BuildRequires:  yast2 >= 4.0.12
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 

--- a/src/lib/y2firewall/clients/proposal.rb
+++ b/src/lib/y2firewall/clients/proposal.rb
@@ -114,7 +114,7 @@ module Y2Firewall
       # @return [Array<String>] services and ports descriptions
       def proposals
         # Filter proposals with content and sort them
-        [firewall_proposal, ssh_port_proposal, sshd_proposal, vnc_fw_proposal].compact
+        [firewall_proposal, sshd_proposal, ssh_port_proposal, vnc_fw_proposal].compact
       end
 
       # Returns the VNC-port part of the firewall proposal description
@@ -138,7 +138,7 @@ module Y2Firewall
       # Returns nil if this part should be skipped
       # @return [String] proposal html text
       def ssh_port_proposal
-        return nil unless @settings.enable_sshd
+        return nil unless @settings.enable_firewall
 
         if @settings.open_ssh
           _("SSH port will be open (<a href=\"%s\">block</a>)") % LINK_BLOCK_SSH_PORT

--- a/src/lib/y2firewall/dialogs/proposal.rb
+++ b/src/lib/y2firewall/dialogs/proposal.rb
@@ -24,7 +24,6 @@ require "cwm/dialog"
 require "y2firewall/widgets/proposal"
 
 Yast.import "Hostname"
-Yast.import "Linuxrc"
 Yast.import "Mode"
 
 module Y2Firewall
@@ -50,10 +49,7 @@ module Y2Firewall
                 0.5,
                 0.5,
                 VBox(
-                  Left(Widgets::EnableFirewall.new(@settings)),
-                  Left(Widgets::EnableSSHD.new(@settings)),
-                  sshd_port_ui,
-                  vnc_ports_ui
+                  Widgets::FirewallSSHProposal.new(@settings)
                 )
               )
             )
@@ -88,16 +84,6 @@ module Y2Firewall
       # @return [String]
       def hostname
         @hostname ||= Yast::Hostname.CurrentHostname
-      end
-
-      def sshd_port_ui
-        Left(Widgets::OpenSSHPort.new(@settings))
-      end
-
-      def vnc_ports_ui
-        return Empty() unless Yast::Linuxrc.vnc
-
-        Left(Widgets::OpenVNCPorts.new(@settings))
       end
 
       def should_open_dialog?

--- a/src/lib/y2firewall/widgets/proposal.rb
+++ b/src/lib/y2firewall/widgets/proposal.rb
@@ -30,8 +30,6 @@ module Y2Firewall
     # open/close checkbox widgets when the firewall is disable
     class FirewallSSHProposal < CWM::CustomWidget
       def initialize(settings)
-        self.handle_all_events = true
-
         @settings = settings
 
         @port_widgets = [Widgets::OpenSSHPort.new(@settings)]
@@ -83,14 +81,14 @@ module Y2Firewall
 
       def handle
         @widgets.map do |widget|
-          value ? widget.enable : widget.disable
+          checked? ? widget.enable : widget.disable
         end
 
         nil
       end
 
       def store
-        value ? @settings.enable_firewall! : @settings.disable_firewall!
+        checked? ? @settings.enable_firewall! : @settings.disable_firewall!
       end
 
       def help
@@ -129,7 +127,7 @@ module Y2Firewall
       end
 
       def store
-        value ? @settings.enable_sshd! : @settings.disable_sshd!
+        checked? ? @settings.enable_sshd! : @settings.disable_sshd!
       end
 
       def help
@@ -162,7 +160,7 @@ module Y2Firewall
       end
 
       def store
-        value ? @settings.open_ssh! : @settings.close_ssh!
+        checked? ? @settings.open_ssh! : @settings.close_ssh!
       end
     end
 
@@ -187,7 +185,7 @@ module Y2Firewall
       end
 
       def store
-        value ? @settings.open_vnc! : @settings.close_vnc!
+        checked? ? @settings.open_vnc! : @settings.close_vnc!
       end
 
       def help

--- a/test/lib/y2firewall/dialogs/proposal_test.rb
+++ b/test/lib/y2firewall/dialogs/proposal_test.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env rspec
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require_relative "../../../test_helper.rb"
+
+require "cwm/rspec"
+require "y2firewall/dialogs/proposal"
+
+describe Y2Firewall::Dialogs::Proposal do
+  let(:settings) { instance_double("Y2Firewall::ProposalSettings") }
+
+  subject { described_class.new(settings) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/lib/y2firewall/widgets/proposal_test.rb
+++ b/test/lib/y2firewall/widgets/proposal_test.rb
@@ -1,0 +1,333 @@
+#!/usr/bin/env rspec
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require_relative "../../../test_helper.rb"
+require "cwm/rspec"
+require "y2firewall/widgets/proposal"
+require "y2firewall/proposal_settings"
+
+require "cwm/rspec"
+
+RSpec.shared_examples "CWM::CheckBox" do
+  include_examples "CWM::AbstractWidget"
+  include_examples "CWM::ValueBasedWidget"
+end
+
+describe Y2Firewall::Widgets do
+  let(:proposal_settings) do
+    instance_double(
+      Y2Firewall::ProposalSettings, enable_firewall: true, enable_sshd: true,
+        open_ssh: true, open_vnc: true
+    )
+  end
+
+  describe Y2Firewall::Widgets::FirewallSSHProposal do
+    let(:widget) { described_class.new(proposal_settings) }
+
+    describe "#initialize" do
+      let(:vnc) { true }
+      before do
+        allow(Yast::Linuxrc).to receive("vnc").and_return(vnc)
+      end
+
+      it "initializes all the widgets that will be shown" do
+        expect(widget.send("widgets").size).to eq(4)
+      end
+
+      context "when vnc was given by Linuxrc" do
+        it "shows the open/close VNC Port widget" do
+          expect(Y2Firewall::Widgets::OpenVNCPorts).to receive("new")
+
+          described_class.new(proposal_settings)
+        end
+      end
+
+      context "when vnc was not given by Linuxrc" do
+        let(:vnc) { false }
+
+        it "does not show the open/close VNC Port widget" do
+          expect(Y2Firewall::Widgets::OpenVNCPorts).to_not receive("new")
+
+          described_class.new(proposal_settings)
+        end
+      end
+    end
+  end
+
+  describe Y2Firewall::Widgets::EnableFirewall do
+    let(:widgets) do
+      [
+        instance_double(Y2Firewall::Widgets::OpenVNCPorts, enable: true, disable: true),
+        instance_double(Y2Firewall::Widgets::OpenSSHPort, enable: true, disable: true)
+      ]
+    end
+
+    subject { described_class.new(proposal_settings, widgets) }
+
+    include_examples "CWM::CheckBox"
+
+    describe "#init" do
+      context "when firewall service is enabled in the proposal settings" do
+        it "initializes the widget checked" do
+          allow(proposal_settings).to receive("enable_firewall").and_return(true)
+          expect(subject).to receive("value=").with(true)
+
+          subject.init
+        end
+      end
+
+      context "when firewall service is disabled in the proposal settings" do
+        it "initializes the widget unchecked" do
+          allow(proposal_settings).to receive("enable_firewall").and_return(false)
+          expect(subject).to receive("value=").with(false)
+
+          subject.init
+        end
+      end
+    end
+
+    describe "#handle" do
+      before do
+        subject.init
+      end
+
+      it "returns nil" do
+        expect(subject.handle).to eq(nil)
+      end
+
+      context "when checked" do
+        it "enables all the widgets given at initialization" do
+          allow(subject).to receive(:checked?).and_return(true)
+          expect(widgets).to all(receive("enable"))
+
+          subject.handle
+        end
+      end
+
+      context "when unchecked" do
+        it "disables all the widgets given at initialization" do
+          allow(subject).to receive(:checked?).and_return(false)
+          expect(widgets).to all(receive("disable"))
+
+          subject.handle
+        end
+      end
+    end
+
+    describe "#store" do
+      context "when checked" do
+        it "sets firewall service to be enabled in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(true)
+          expect(proposal_settings).to receive("enable_firewall!")
+
+          subject.store
+        end
+      end
+
+      context "when unchecked" do
+        it "sets firewall service to be disabled in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(false)
+          expect(proposal_settings).to receive("disable_firewall!")
+
+          subject.store
+        end
+      end
+    end
+  end
+
+  describe Y2Firewall::Widgets::EnableSSHD do
+    subject { described_class.new(proposal_settings) }
+
+    include_examples "CWM::CheckBox"
+
+    describe "#init" do
+      context "when ssh service is enabled in the proposal settings" do
+        it "initializes the widget checked" do
+          allow(proposal_settings).to receive("enable_sshd").and_return(true)
+          expect(subject).to receive("value=").with(true)
+
+          subject.init
+        end
+      end
+
+      context "when ssh service is disabled in the proposal settings" do
+        it "initializes the widget unchecked" do
+          allow(proposal_settings).to receive("enable_sshd").and_return(false)
+          expect(subject).to receive("value=").with(false)
+
+          subject.init
+        end
+      end
+    end
+
+    describe "#store" do
+      context "when checked" do
+        it "sets sshd service to be enabled in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(true)
+          expect(proposal_settings).to receive("enable_sshd!")
+
+          subject.store
+        end
+      end
+
+      context "when unchecked" do
+        it "sets sshd service to be disabled in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(false)
+          expect(proposal_settings).to receive("disable_sshd!")
+
+          subject.store
+        end
+      end
+    end
+  end
+
+  describe Y2Firewall::Widgets::OpenSSHPort do
+    subject { described_class.new(proposal_settings) }
+
+    include_examples "CWM::CheckBox"
+
+    describe "#init" do
+      context "when the firewall service is enabled in the proposal settings" do
+        it "initializes enabled the widget" do
+          allow(proposal_settings).to receive("enable_firewall").and_return(true)
+          expect(subject).to receive("enable")
+
+          subject.init
+        end
+      end
+
+      context "when the firewall service is disabled in the proposal settings" do
+        it "initializes disabled the widget" do
+          allow(proposal_settings).to receive("enable_firewall").and_return(false)
+          expect(subject).to receive("disable")
+
+          subject.init
+        end
+      end
+
+      describe "#init" do
+        context "when ssh port is opened in the proposal settings" do
+          it "initializes the widget checked" do
+            allow(proposal_settings).to receive("open_ssh").and_return(true)
+            expect(subject).to receive("value=").with(true)
+
+            subject.init
+          end
+        end
+
+        context "when ssh port is closed in the proposal settings" do
+          it "initializes the widget unchecked" do
+            allow(proposal_settings).to receive("open_ssh").and_return(false)
+            expect(subject).to receive("value=").with(false)
+
+            subject.init
+          end
+        end
+      end
+    end
+
+    describe "#store" do
+      context "when checked" do
+        it "sets ssh ports to be opened in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(true)
+          expect(proposal_settings).to receive("open_ssh!")
+
+          subject.store
+        end
+      end
+
+      context "when unchecked" do
+        it "sets ssh ports to be closed in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(false)
+          expect(proposal_settings).to receive("close_ssh!")
+
+          subject.store
+        end
+      end
+    end
+  end
+
+  describe Y2Firewall::Widgets::OpenVNCPorts do
+    subject { described_class.new(proposal_settings) }
+
+    include_examples "CWM::CheckBox"
+
+    describe "#init" do
+      context "when the firewall service is enabled in the proposal settings" do
+        it "initializes enabled the widget" do
+          allow(proposal_settings).to receive("enable_firewall").and_return(true)
+          expect(subject).to receive("enable")
+
+          subject.init
+        end
+      end
+
+      context "when the firewall service is disabled in the proposal settings" do
+        it "initializes disabled the widget" do
+          allow(proposal_settings).to receive("enable_firewall").and_return(false)
+          expect(subject).to receive("disable")
+
+          subject.init
+        end
+      end
+
+      describe "#init" do
+        context "when vnc ports are opened in the proposal settings" do
+          it "initializes the widget checked" do
+            allow(proposal_settings).to receive("open_vnc").and_return(true)
+            expect(subject).to receive("value=").with(true)
+
+            subject.init
+          end
+        end
+
+        context "when vnc ports are closed in the proposal settings" do
+          it "initializes the widget unchecked" do
+            allow(proposal_settings).to receive("open_vnc").and_return(false)
+            expect(subject).to receive("value=").with(false)
+
+            subject.init
+          end
+        end
+      end
+    end
+
+    describe "#store" do
+      context "when checked" do
+        it "sets vnc ports to be opened in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(true)
+          expect(proposal_settings).to receive("open_vnc!")
+
+          subject.store
+        end
+      end
+
+      context "when unchecked" do
+        it "sets vnc ports to be closed in the proposal settings" do
+          allow(subject).to receive(:checked?).and_return(false)
+          expect(proposal_settings).to receive("close_vnc!")
+
+          subject.store
+        end
+      end
+    end
+  end
+end

--- a/test/lib/y2firewall/widgets/proposal_test.rb
+++ b/test/lib/y2firewall/widgets/proposal_test.rb
@@ -24,8 +24,6 @@ require "cwm/rspec"
 require "y2firewall/widgets/proposal"
 require "y2firewall/proposal_settings"
 
-require "cwm/rspec"
-
 RSpec.shared_examples "CWM::CheckBox" do
   include_examples "CWM::AbstractWidget"
   include_examples "CWM::ValueBasedWidget"


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1068354

- When Firewalld is disabled, the port links are not shown and in the dialog the check boxes are disabled.

## Screenshots with a complete sequence:

![screenshot_testing_2017-11-21_10 07 57](https://user-images.githubusercontent.com/7056681/33066728-08f223ee-cea4-11e7-9436-a347fc496a18.png)
![screenshot_testing_2017-11-21_10 08 05](https://user-images.githubusercontent.com/7056681/33066727-08d0bce0-cea4-11e7-971b-5d6dedf395bd.png)
![screenshot_testing_2017-11-21_10 08 10](https://user-images.githubusercontent.com/7056681/33066726-08accf38-cea4-11e7-86f3-74728758850f.png)
![screenshot_testing_2017-11-21_10 08 16](https://user-images.githubusercontent.com/7056681/33066725-088ced94-cea4-11e7-9963-a742d64baa7a.png)
![screenshot_testing_2017-11-21_10 08 30](https://user-images.githubusercontent.com/7056681/33066723-086b8a3c-cea4-11e7-9b25-a0494ad2323c.png)
![screenshot_testing_2017-11-21_10 08 37](https://user-images.githubusercontent.com/7056681/33066722-084b5bfe-cea4-11e7-9ed6-4e6aa3bed648.png)