### PR TITLE
Try to import again when writing if it failed prefiously

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,8 +1,10 @@
 -------------------------------------------------------------------
-Fri Jan 26 01:44:25 UTC 2018 - knut.anderssen@suse.com
+Wed Jan 31 07:41:26 UTC 2018 - knut.anderssen@suse.com
 
-- Enable or disable firewalld depending on the profile.
-  (fate#323460)
+- AutoYaST: (fate#323460)
+  * Try to import again during writing in case it was not completed
+  previously (ex: firewalld was not installed).
+  *  Enable or disable firewalld depending on the profile
 - 4.0.10
 
 -------------------------------------------------------------------

--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 26 01:44:25 UTC 2018 - knut.anderssen@suse.com
+
+- Enable or disable firewalld depending on the profile.
+  (fate#323460)
+- 4.0.10
+
+-------------------------------------------------------------------
 Fri Jan 19 08:44:25 UTC 2018 - knut.anderssen@suse.com
 
 - AutoYaST: fixed default valur for log denied packets when using

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -27,13 +27,14 @@ Group:	        System/YaST
 License:        GPL-2.0
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 3.1.10
-# IP::CheckNetwork
-BuildRequires:  yast2 >= 4.0.12
+
+# Firewalld read?
+BuildRequires:  yast2 >= 4.0.45
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
-# FirewallD default zone & export support
-Requires:       yast2 >= 4.0.32
+# Firewalld read?
+Requires:       yast2 >= 4.0.45
 
 # ButtonBox widget
 Conflicts:	yast2-ycp-ui-bindings < 2.17.3

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -40,8 +40,10 @@ module Y2Firewall
         # successfully or not
         attr_accessor :imported
         # @return [Boolean] whether the firewalld service has to be enabled
+        # after writing the configuration
         attr_accessor :enable
         # @return [Boolean] whether the firewalld service has to be started
+        # after writing the configuration
         attr_accessor :start
         # @return [Hash]
         attr_accessor :profile
@@ -117,7 +119,7 @@ module Y2Firewall
       end
 
       # A map with the packages that needs to be installed or removed for
-      # configuring properly firewalld
+      # configuring firewalld properly
       #
       # @return packages [Hash{String => Array<String>} ] of packages to be
       # installed or removed
@@ -142,41 +144,57 @@ module Y2Firewall
         start? ? firewalld.start : firewalld.stop
       end
 
+      # Return a firewall importer
+      #
+      # @return [Y2Firewall::Importer]
       def importer
-        @importer ||= ::Y2Firewall::Importer.new
+        @importer ||= Importer.new
       end
 
+      # Return a firewalld singleton instance
+      #
+      # @return [Y2Firewall::Firewalld] singleton instance
       def firewalld
-        ::Y2Firewall::Firewalld.instance
+        Firewalld.instance
       end
 
+      # @return [Y2Firewall::ProposalSettings]
       def settings
         ProposalSettings.instance
       end
 
-      # Whether the firewalld service has to be enable or not
+      # Set that the firewall has to be enabled when writing
       def enable
         self.class.enable = true
       end
 
-      # Whether the firewalld service has to be enable or not
+      # Whether the firewalld service has to be enable or disable when writing
+      #
+      # @return [Boolean] true if has to be enabled; false otherwise
       def enable?
         !!self.class.enable
       end
 
+      # Set that the firewall has to be started when writing
       def start
         self.class.start = true
       end
 
+      # Whether the firewalld service has to be started or stopped when writing
+      #
+      # @return [Boolean] true if has to be started; false otherwise
       def start?
         !!self.class.start
       end
 
+      # Set that the firewalld configuration has been completely imported
       def imported
         self.class.imported = true
       end
 
-      # @return [Boolean] whether the configuration has been imported or not
+      # Whether the firewalld configuration has been already imported or not
+      #
+      # @return [Boolean] true if has been imported; false otherwise
       def imported?
         !!self.class.imported
       end

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "y2firewall/firewalld"
 require "y2firewall/importer"
+require "y2firewall/proposal_settings"
 require "installation/auto_client"
 
 module Y2Firewall
@@ -30,34 +31,55 @@ module Y2Firewall
     # goes through the configuration and return the setting.
     # Does not do any changes to the configuration.
     class Auto < ::Installation::AutoClient
+      include Yast::Logger
       class << self
         attr_accessor :changed
+        attr_accessor :imported
         attr_accessor :enable
         attr_accessor :start
+        attr_accessor :profile
       end
 
+      # Constructor
       def initialize
         textdomain "firewall"
-
-        self.class.enable = false
-        self.class.start = false
       end
 
+      # Configuration summary
+      #
+      # @return [String]
       def summary
+        return "" if !firewalld.installed?
+
         firewalld.api.list_all_zones.join("\n")
       end
 
+      # Import the firewall configuration
+      #
+      # @param profile [Hash] firewall profile section to be imported
+      # @return [Boolean]
       def import(profile)
-        firewalld.read
-        self.class.enable = true if profile.fetch("enable_firewall", true)
-        self.class.start = true if profile.fetch("start_firewall", true)
+        self.class.profile = profile
+        return false unless read
+
+        # Obtains the default from the control file (settings) if not present.
+        self.class.enable = true if profile.fetch("enable_firewall", settings.enable_firewall)
+        self.class.start = true if profile.fetch("start_firewall", false)
         importer.import(profile)
+        self.class.imported = true
       end
 
+      # Export the current firewalld configuration
+      #
+      # @param profile [Hash] firewall profile section to be imported
+      # @return [Boolean]
       def export
         firewalld.export
       end
 
+      # Reset the current firewalld configuration.
+      #
+      # @return [Boolean]
       def reset
         importer.import({})
       end
@@ -68,18 +90,30 @@ module Y2Firewall
         :next
       end
 
+      # Write the imported configuration to firewalld. If for some reason the
+      # configuration was not imported from the profile, it tries to import
+      # it again.
       def write
+        return false if !firewalld.installed?
+        import(self.class.profile) unless self.class.imported
+        return false unless self.class.imported
+
         firewalld.write
-        self.class.enable ? firewalld.enable! : firewalld.disable!
-        self.class.start ? firewalld.start! : firewalld.stop!
+        activate_service
       end
 
+      # Read the currnet firewalld configuration
       def read
-        firewalld.read if firewalld.installed?
+        return false if !firewalld.installed?
+        firewalld.read
       end
 
+      # A map with the packages that needs to be installed or removed for
+      # configuring properly firewalld
+      #
+      # @return packages [Hash] of packages to be installed or removed
       def packages
-        ["firewalld"]
+        { "install" => ["firewalld"], "remove" => [] }
       end
 
       def modified
@@ -92,12 +126,22 @@ module Y2Firewall
 
     private
 
+      # Depending on the profile it activate or not the firewalld service
+      def activate_service
+        self.class.enable ? firewalld.enable! : firewalld.disable!
+        self.class.start ? firewalld.start : firewalld.stop
+      end
+
       def importer
         @importer ||= ::Y2Firewall::Importer.new
       end
 
       def firewalld
         ::Y2Firewall::Firewalld.instance
+      end
+
+      def settings
+        ProposalSettings.instance
       end
     end
   end

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -32,10 +32,15 @@ module Y2Firewall
     class Auto < ::Installation::AutoClient
       class << self
         attr_accessor :changed
+        attr_accessor :enable
+        attr_accessor :start
       end
 
       def initialize
         textdomain "firewall"
+
+        self.class.enable = false
+        self.class.start = false
       end
 
       def summary
@@ -44,7 +49,8 @@ module Y2Firewall
 
       def import(profile)
         firewalld.read
-
+        self.class.enable = true if profile.fetch("enable_firewall", true)
+        self.class.start = true if profile.fetch("start_firewall", true)
         importer.import(profile)
       end
 
@@ -64,6 +70,8 @@ module Y2Firewall
 
       def write
         firewalld.write
+        self.class.enable ? firewalld.enable! : firewalld.disable!
+        self.class.start ? firewalld.start! : firewalld.stop!
       end
 
       def read

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -47,7 +47,7 @@ module Y2Firewall
       end
 
       def modes
-        [:installation, :autoinst]
+        [:installation]
       end
 
       def write

--- a/src/lib/y2firewall/importer.rb
+++ b/src/lib/y2firewall/importer.rb
@@ -28,6 +28,7 @@ module Y2Firewall
   # This class is responsible for importing firewalld AutoYaST configuration
   # supporting the new firewalld schema but also the SuSEFirewall one.
   class Importer
+    include Yast::Logger
     # Import the given configuration
     #
     # @param [Hash] AutoYaST profile firewall's section

--- a/src/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/src/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -26,6 +26,7 @@ module Y2Firewall
     # This class is reponsible of parsing SuSEFirewall2 firewalld profile's
     # section configuring the Y2Firewall::Firewalld instance according to it.
     class SuseFirewall
+      include Yast::Logger
       # @return [Hash] AutoYaST profile firewall's section
       attr_accessor :profile
 
@@ -64,11 +65,14 @@ module Y2Firewall
       # It processes the profile configuring the firewalld zones that match
       # better with the SuSEFirewall2 ones.
       def import
-        return true if profile.empty?
+        if profile.empty?
+          log.info "The profile is empty, there is nothing to import"
+          return true
+        end
         zones.each { |z| process_zone(z) }
         if ipsec_trust_zone
           zone = firewalld.find_zone(zone.equivalent(ipsec_trust_zone))
-          zone.services << "ipsec"
+          (zone.services << "ipsec") if zone
         end
         firewalld.log_denied_packets = log_denied_packets
         true
@@ -81,7 +85,12 @@ module Y2Firewall
       # object.
       # @param name [String] SuSEFirewall2 zone name
       def process_zone(name)
+        log.info "Processing zone #{name}"
         zone = firewalld.find_zone(zone_equivalent(name))
+        if !zone
+          log.error "There is no zone for #{name}"
+          return
+        end
 
         if interfaces(name)
           zone.interfaces = interfaces(name)

--- a/src/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/src/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -164,7 +164,7 @@ module Y2Firewall
       # configured
       def tcp_ports(zone)
         ports = profile["FW_SERVICES_#{zone}_TCP"]
-        ports ? ports.split(" ").map { |p| "#{p}/tcp" } : nil
+        ports ? ports.split(" ").map { |p| "#{p.sub(":", "-")}/tcp" } : nil
       end
 
       # Obtain the UDP ports for the given SuSEFIrewall2 zone name from the
@@ -175,7 +175,7 @@ module Y2Firewall
       # configured
       def udp_ports(zone)
         ports = profile["FW_SERVICES_#{zone}_UDP"]
-        ports ? ports.split(" ").map { |p| "#{p}/udp" } : nil
+        ports ? ports.split(" ").map { |p| "#{p.sub(":", "-")}/udp" } : nil
       end
 
       # Obtain the RPC ports for the given SuSEFIrewall2 zone name from the

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -76,7 +76,7 @@ describe Y2Firewall::Clients::Auto do
         expect(subject.import(arguments)).to eq(true)
       end
 
-      it "marks the importation as done or completed" do
+      it "marks the importation as done" do
         subject.import(arguments)
         expect(subject.class.imported).to eq(true)
       end
@@ -126,14 +126,14 @@ describe Y2Firewall::Clients::Auto do
       expect(subject.write).to eq(false)
     end
 
-    it "tries to import again the profile if was not imported" do
+    it "tries to import again the profile if it was not imported" do
       allow(subject.class).to receive(:profile).and_return(arguments)
       expect(subject).to receive(:import).with(arguments).and_return(false)
 
       subject.write
     end
 
-    it "writes the configuration imported" do
+    it "writes the imported configuration" do
       allow(subject.class).to receive(:imported).and_return(true)
       allow(subject).to receive(:activate_service)
       expect(firewalld).to receive(:write)

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -27,7 +27,9 @@ describe Y2Firewall::Clients::Auto do
   let(:importer) { double("Y2Firewall::Importer", import: true) }
 
   before do
+    subject.class.imported = false
     allow(firewalld).to receive(:read)
+    allow(firewalld).to receive(:installed?).and_return(true)
     allow(subject).to receive(:importer).and_return(importer)
   end
 
@@ -49,7 +51,9 @@ describe Y2Firewall::Clients::Auto do
   end
 
   describe "#import" do
-    let(:arguments) { { "FW_MASQUERADE" => "yes" } }
+    let(:arguments) do
+      { "FW_MASQUERADE" => "yes", "enable_firewall" => false, "start_firewall" => false }
+    end
 
     it "reads the current firewalld configuration" do
       expect(firewalld).to receive(:read)
@@ -57,14 +61,38 @@ describe Y2Firewall::Clients::Auto do
       subject.import(arguments)
     end
 
-    it "pass its arguments to the firewalld importer" do
-      expect(importer).to receive(:import).with(arguments)
+    context "when the current configuration was read correctly" do
+      before do
+        allow(firewalld).to receive(:read).and_return(true)
+      end
 
-      subject.import(arguments)
+      it "pass its arguments to the firewalld importer" do
+        expect(importer).to receive(:import).with(arguments)
+
+        subject.import(arguments)
+      end
+
+      it "returns true if import success" do
+        expect(subject.import(arguments)).to eq(true)
+      end
+
+      it "marks the importation as done or completed" do
+        subject.import(arguments)
+        expect(subject.class.imported).to eq(true)
+      end
     end
 
-    it "returns true if import success" do
-      expect(subject.import(arguments)).to eq(true)
+    context "when the current configuration was not read" do
+      it "returns false" do
+        expect(firewalld).to receive(:read).and_return(false)
+        expect(subject.import(arguments)).to eq(false)
+      end
+
+      it "does not mark the importation as done or completed" do
+        expect(firewalld).to receive(:read).and_return(false)
+        subject.import(arguments)
+        expect(subject.class.imported).to eq(false)
+      end
     end
   end
 
@@ -84,6 +112,41 @@ describe Y2Firewall::Clients::Auto do
       expect(importer).to receive(:import).with({})
 
       subject.reset
+    end
+  end
+
+  describe "#write" do
+    let(:arguments) do
+      { "FW_MASQUERADE" => "yes", "enable_firewall" => false, "start_firewall" => false }
+    end
+
+    it "returns false if firewalld is not installed" do
+      expect(firewalld).to receive(:installed?).and_return(false)
+
+      expect(subject.write).to eq(false)
+    end
+
+    it "tries to import again the profile if was not imported" do
+      allow(subject.class).to receive(:profile).and_return(arguments)
+      expect(subject).to receive(:import).with(arguments).and_return(false)
+
+      subject.write
+    end
+
+    it "writes the configuration imported" do
+      allow(subject.class).to receive(:imported).and_return(true)
+      allow(subject).to receive(:activate_service)
+      expect(firewalld).to receive(:write)
+
+      subject.write
+    end
+
+    it "activates or deactives the firewalld service based on the profile" do
+      allow(subject.class).to receive(:imported).and_return(true)
+      expect(firewalld).to receive(:write)
+      expect(subject).to receive(:activate_service)
+
+      subject.write
     end
   end
 end

--- a/test/lib/y2firewall/clients/installation_finish_test.rb
+++ b/test/lib/y2firewall/clients/installation_finish_test.rb
@@ -14,7 +14,7 @@ describe Y2Firewall::Clients::InstallationFinish do
 
   describe "#modes" do
     it "runs on installation and autoinstallation" do
-      expect(subject.modes).to eq([:installation, :autoinst])
+      expect(subject.modes).to eq([:installation])
     end
   end
 

--- a/test/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/test/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -42,7 +42,8 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
         "FW_DEV_INT"            => "eth1",
         "FW_DEV_DMZ"            => "eth2 any",
         "FW_CONFIGURATIONS_EXT" => "dhcp-server sshd netbios-server vnc-server",
-        "FW_SERVICES_EXT_TCP"   => "80 443",
+        "FW_SERVICES_EXT_TCP"   => "80 443 8080:8084",
+        "FW_SERVICES_EXT_UDP"   => "53",
         "FW_SERVICES_EXT_IP"    => "esp",
         "FW_MASQUERADE"         => masquerade
       }
@@ -85,6 +86,7 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
 
           expect(public_zone.interfaces).to eq(["eth0"])
           expect(public_zone.services).to eq(["dhcp", "ssh", "samba", "vnc-server"])
+          expect(public_zone.ports).to eq(["80/tcp", "443/tcp", "8080-8084/tcp", "53/udp"])
           expect(public_zone.protocols).to eq(["esp"])
         end
       end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/jL8fhEKw/1091-5-firewall-firewalld-is-the-new-susefirewall-autoyast-support)

1. During the second stage, an Import takes place before the Write. When the list of packages needed for configuring the firewall are not present, them are installed after the Import and we need them before it.
  This PR tries to import again when writing if the import was not completed previously.

2. The firewalld service is enabled or disabled depending on the profile
3. Fixed the requirement of packages to be installed (wrong implementation) see yast/yast-yast2#681

It depends on yast/yast-yast2#684



