### PR TITLE
Use internal zone when the protection from INT is enabled

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -2,10 +2,11 @@
 Tue Mar  6 07:04:46 UTC 2018 - knut.anderssen@suse.com
 
 - SuSEFirewall2 importer changes (fate#323460)
-  - Use internal zone when the protection from the internal zone is
-  enabled.
+  - Use internal zone instead of trusted when the protection from
+    the INT zone is enabled which fits better with the definition.
   - Removed the mapping of apache2 and apache2-ssl services to
-    firewalld services.
+    firewalld services since the apache package will provide the
+    services definition and we will not use firewall defaults.
 - 4.0.18
 
 -------------------------------------------------------------------

--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Mar  6 07:04:46 UTC 2018 - knut.anderssen@suse.com
+
+- SuSEFirewall2 importer changes (fate#323460)
+  - Use internal zone when the protection from the internal zone is
+  enabled.
+  - Removed the mapping of apache2 and apache2-ssl services to
+    firewalld services.
+- 4.0.18
+
+-------------------------------------------------------------------
 Tue Feb 27 13:08:22 UTC 2018 - jreidinger@suse.com
 
 - Added textdomain for translation (bnc#1083015)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.17
+Version:        4.0.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/src/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -42,8 +42,6 @@ module Y2Firewall
       # Best effort conversion of SuSEFirewall2 services into firewalld
       # predefined ones.
       SERVICE_MAP = {
-        "apache2"           => ["http"],
-        "apache2-ssl"       => ["https"],
         "bind"              => ["dns"],
         "dhcp-server"       => ["dhcp"],
         "dhcp6-server"      => ["dhcpv6"],
@@ -77,7 +75,8 @@ module Y2Firewall
         "FW_LOG_ACCEPT_CRIT",
         "FW_LOG_DROP_CRIT",
         "FW_LOG_DROP_ALL",
-        "FW_MASQUERADE"
+        "FW_MASQUERADE",
+        "FW_PROTECT_FROM_INT"
       ].freeze
 
       # @return [Array<string>] list of zones
@@ -282,12 +281,19 @@ module Y2Firewall
       def zone_equivalent(name)
         case name.upcase
         when "INT"
-          "trusted"
+          trusted? ? "trusted" : "internal"
         when "EXT"
           masquerade? ? "external" : "public"
         when "DMZ"
           "dmz"
         end
+      end
+
+      # Return whether internal network is trusted or not
+      #
+      # @return [Boolean] true if trusted; false otherwise
+      def trusted?
+        profile.fetch("FW_PROTECT_FROM_INT", "no") == "no"
       end
 
       # Return whether masquerade is configured or not

--- a/test/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/test/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -81,6 +81,16 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
         expect(firewalld.default_zone).to eql("dmz")
       end
 
+      context "and protection from INT zone is not defined" do
+        let(:profile) { { "FW_DEV_INT" => "eth1" } }
+
+        it "configures the INT zone as the trusted" do
+          trusted = firewalld.find_zone("trusted")
+
+          expect(trusted.interfaces).to eq(["eth1"])
+        end
+      end
+
       context "and protection from INT zone is disabled" do
         it "configures the INT zone as the trusted" do
           trusted = firewalld.find_zone("trusted")

--- a/test/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/test/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -30,6 +30,7 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
   let(:known_zones) { Y2Firewall::Firewalld::Zone.known_zones.keys }
   let(:empty_zones) { known_zones.map { |name| Y2Firewall::Firewalld::Zone.new(name: name) } }
   let(:masquerade) { "yes" }
+  let(:int_protected) { "no" }
 
   before do
     firewalld.zones = empty_zones
@@ -52,7 +53,8 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
         "FW_MASQUERADE"         => masquerade,
         "FW_LOG_DROP_CRIT"      => "yes",
         "FW_LOG_DROP_ALL"       => "no",
-        "FW_LOG_ACCEPT_CRIT"    => "no"
+        "FW_LOG_ACCEPT_CRIT"    => "no",
+        "FW_PROTECT_FROM_INT"   => int_protected
       }
     end
 
@@ -69,12 +71,6 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
         subject.import
       end
 
-      it "configures the INT zone as the trusted" do
-        trusted = firewalld.find_zone("trusted")
-
-        expect(trusted.interfaces).to eq(["eth1"])
-      end
-
       it "configures the DMZ zone as the dmz" do
         dmz = firewalld.find_zone("dmz")
 
@@ -83,6 +79,24 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
 
       it "sets the default zone as the one with the 'any' interface" do
         expect(firewalld.default_zone).to eql("dmz")
+      end
+
+      context "and protection from INT zone is disabled" do
+        it "configures the INT zone as the trusted" do
+          trusted = firewalld.find_zone("trusted")
+
+          expect(trusted.interfaces).to eq(["eth1"])
+        end
+      end
+
+      context "and protection from INT zone is enabled" do
+        let(:int_protected) { "yes" }
+
+        it "configures the INT zone as the internal" do
+          internal = firewalld.find_zone("internal")
+
+          expect(internal.interfaces).to eq(["eth1"])
+        end
       end
 
       context "and masquerade is disabled" do


### PR DESCRIPTION
When the profile contains the  `FW_PROTEC_FROM_INT` variable as "yes" then the `INT` zone will be mapped to the `internal` one.

Removed also the mapping of apache2 services into firewalld ones as the apache2 services definition will be finally shipped with the apache package.

Already documented in the AutoYaST main profiles changes from SLE12 to SLE15 PBI (https://github.com/yast/yast-autoinstallation/pull/408/files#diff-12924b8e025b11c36c24149f59c4be34R29)


