### PR TITLE
Some fixes to firewall schema (bsc#1013047)

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 13 07:24:55 UTC 2018 - knut.anderssen@suse.com
+
+- Some fixes to the firewall AY schema (bsc#1013047)
+  - Use "name" in zones
+  - "default_zone" is a firewall attribute
+- 4.0.19
+
+-------------------------------------------------------------------
 Tue Mar  6 07:04:46 UTC 2018 - knut.anderssen@suse.com
 
 - SuSEFirewall2 importer changes (fate#323460)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.18
+Version:        4.0.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/firewall.rnc
+++ b/src/autoyast-rnc/firewall.rnc
@@ -24,7 +24,6 @@ y2_firewall =
   | FW_SERVICES_EXT_IP
   | start_firewall
   | enable_firewall
-  | default_zone
   | FW_ALLOW_FW_BROADCAST_DMZ
   | FW_ALLOW_FW_BROADCAST_INT
   | FW_ALLOW_FW_BROADCAST_EXT
@@ -85,7 +84,6 @@ FW_SERVICES_EXT_TCP = element FW_SERVICES_EXT_TCP { text }
 FW_SERVICES_EXT_IP = element FW_SERVICES_EXT_IP { text }
 start_firewall = element start_firewall { BOOLEAN }
 enable_firewall = element enable_firewall { BOOLEAN }
-default_zone = element default_zone { text }
 FW_ALLOW_FW_BROADCAST_DMZ = element FW_ALLOW_FW_BROADCAST_DMZ { text }
 FW_ALLOW_FW_BROADCAST_EXT = element FW_ALLOW_FW_BROADCAST_EXT { text }
 FW_ALLOW_FW_BROADCAST_INT = element FW_ALLOW_FW_BROADCAST_INT { text }
@@ -131,36 +129,39 @@ zones =
 
 zone =
   element zone {
-    interfaces
-    | services
-    | ports
-    | protocols
-    | masquerade
+    zone_name &
+    fwd_interfaces? &
+    fwd_services? &
+    fwd_ports? &
+    fwd_protocols? &
+    masquerade?
   }
 
-services =
+fwd_services =
   element services {
     LIST,
-    element service {text}+
+    element service {text}*
   }
 
-interfaces =
+fwd_interfaces =
   element interfaces {
     LIST,
-    element interface {text}+
+    element interface {text}*
   }
 
-ports =
+fwd_ports =
   element ports {
     LIST,
-    element ports {text}+
+    element port {text}*
   }
 
-protocols =
+fwd_protocols =
   element protocols {
     LIST,
-    element protocols {text}+
+    element protocol {text}*
   }
 
+zone_name = element name { text }
+default_zone = element default_zone { text }
 masquerade = element masquerade { BOOLEAN }
 log_denied_packets = element log_denied_packets { text }


### PR DESCRIPTION
- https://trello.com/c/o6xMc6sL/2073-ostumbleweed-p1-1013047-generated-autoyast-profile-does-not-validate-firewall

## Validation
```
$ xmllint -noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng firewalld_profile.xml
firewalld_profile.xml validates
```
## firewalld_profile.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE profile>
<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
  <firewall>
    <enable_firewall config:type="boolean">true</enable_firewall>
    <start_firewall config:type="boolean">true</start_firewall>
    <log_denied_packets>unicast</log_denied_packets>
    <default_zone>external</default_zone>
    <zones config:type="list">
      <zone>
        <name>external</name>
        <interfaces config:type="list">
          <interface>eth0</interface>
        </interfaces>
        <services config:type="list">
          <service>ssh</service>
          <service>dhcp</service>
          <service>dhcpv6</service>
          <service>samba</service>
          <service>vnc-server</service>
        </services>
        <ports config:type="list">
          <port>21/udp</port>
          <port>22/udp</port>
          <port>80/tcp</port>
          <port>443/tcp</port>
          <port>8080/tcp</port>
        </ports>
      </zone>
    </zones>
  </firewall>
</profile>
```