### PR TITLE
Do not support FW_LOG_ACCEPT_CRIT tag

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar 23 11:38:40 UTC 2018 - knut.anderssen@suse.com
+
+- Do not support FW_LOG_ACCEP_CRIT tag as firewalld only log
+  dropped packages and for accepted ones rich rules should be
+  used instead (bsc#1086655)
+- 4.0.21
+
+-------------------------------------------------------------------
 Wed Mar 21 23:42:21 UTC 2018 - knut.anderssen@suse.com
 
 - More fixes to the firewall AY schema (bsc#1013047)

--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,9 +1,10 @@
 -------------------------------------------------------------------
 Fri Mar 23 11:38:40 UTC 2018 - knut.anderssen@suse.com
 
-- Do not support FW_LOG_ACCEP_CRIT tag as firewalld only log
-  dropped packages and for accepted ones rich rules should be
-  used instead (bsc#1086655)
+- AutoYaST SuSEFirewall2 Importer: Removed FW_LOG_ACCEPT_CRIT tag
+  from the list of supported options as firewalld only log dropped
+  packages and for accepted ones rich rules should be used instead
+  (bsc#1086655)
 - 4.0.21
 
 -------------------------------------------------------------------

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.20
+Version:        4.0.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firewall/importer_strategies/suse_firewall.rb
+++ b/src/lib/y2firewall/importer_strategies/suse_firewall.rb
@@ -72,7 +72,6 @@ module Y2Firewall
         "FW_SERVICES_DMZ_IP",
         "FW_SERVICES_EXT_IP",
         "FW_SERVICES_INT_IP",
-        "FW_LOG_ACCEPT_CRIT",
         "FW_LOG_DROP_CRIT",
         "FW_LOG_DROP_ALL",
         "FW_MASQUERADE",
@@ -318,17 +317,10 @@ module Y2Firewall
       #
       # @return [String] all, unicast or off depending on the log config
       def log_denied_packets
-        accept_crit = profile.fetch("FW_LOG_ACCEPT_CRIT", "no") == "yes"
-        drop_all = profile.fetch("FW_LOG_DROP_ALL", "no") == "yes"
-        drop_crit = profile.fetch("FW_LOG_DROP_CRIT", "no") == "yes"
+        return "all" if profile.fetch("FW_LOG_DROP_ALL", "no") == "yes"
+        return "unicast" if profile.fetch("FW_LOG_DROP_CRIT", "no") == "yes"
 
-        if drop_all
-          "all"
-        elsif accept_crit || drop_crit
-          "unicast"
-        else
-          "off"
-        end
+        "off"
       end
 
       # Convenience method which return an instance of Y2Firewall::Firewalld


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1086655

It does not make sense to set the log of denied packets as "unicast" when the log of accepted critical packets is used. That is wrong, so fixed it.