### PR TITLE
Installation: Use tigervnc firewalld service definition

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Apr 21 07:35:42 UTC 2018 - knut.anderssen@suse.com
+
+- AutoYaST: Use tigervnc firewalld service definition instead of
+  the firewalld one (bsc#1088646)
+- 4.0.24
+
+-------------------------------------------------------------------
 Tue Apr 17 11:55:47 CEST 2018 - snwint@suse.de
 
 - consistent wording (open/block) also for VNC ports (bsc#1089789)

--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Sat Apr 21 07:35:42 UTC 2018 - knut.anderssen@suse.com
 
-- AutoYaST: Use tigervnc firewalld service definition instead of
-  the firewalld one (bsc#1088646)
+- During installation, open services defined by (Tigervnc) instead
+  of the 'vnc-server' service that is shipped with (firewalld)
+  (bsc#1081952).
 - 4.0.24
 
 -------------------------------------------------------------------

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.23
+Version:        4.0.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firewall/importer_strategies/firewalld.rb
+++ b/src/lib/y2firewall/importer_strategies/firewalld.rb
@@ -19,6 +19,7 @@
 # current contact information at www.suse.com.
 # ------------------------------------------------------------------------------
 
+require "yast"
 require "y2firewall/firewalld"
 
 module Y2Firewall
@@ -27,6 +28,7 @@ module Y2Firewall
     # firewalld schema is used configuring the Y2Firewall::Firewalld instance
     # according to it.
     class Firewalld
+      include Yast::Logger
       # [Hash] AutoYaST profile firewall's section
       attr_reader :profile
 
@@ -45,6 +47,7 @@ module Y2Firewall
       def import
         return true if profile.empty?
         profile.fetch("zones", []).each do |zone|
+          log.debug "Proccesing zone: #{zone.inspect}"
           process_zone(zone)
         end
 


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/WbNLhdQb/1414-5-15-ga-or-mu-bug-1088647-build-5502-openqa-test-fails-in-yast2vnc-firewalld-does-not-create-rule-for-vnc-and-bug-1088646-build)
- [bsc#1088646](https://bugzilla.suse.com/show_bug.cgi?id=1088646)
