### PR TITLE
Improve allowed services tab

### DIFF
--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -28,14 +28,15 @@ License:        GPL-2.0
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 3.1.10
 
-# Firewalld read?
-BuildRequires:  yast2 >= 4.0.45
+# Extended firewalld API
+# Y2Firewall::Firewalld.instance.current_service_names
+BuildRequires:  yast2 >= 4.0.91
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
-# Firewalld - extended API
-# FIXME: need a fixed Y2Firewall::Helpers::Interfaces
-Requires:       yast2 >= 4.0.49
+# Extended firewalld API
+# Y2Firewall::Firewalld.instance.current_service_names
+Requires:       yast2 >= 4.0.91
 
 # ButtonBox widget
 Conflicts:	yast2-ycp-ui-bindings < 2.17.3

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -48,7 +48,7 @@ module Y2Firewall
       def contents
         return @contents if @contents
 
-        VBox(
+        @contents = VBox(
           HBox(
             VBox(
               Left(Label(_("Known"))),
@@ -136,12 +136,12 @@ module Y2Firewall
           PushButton(
             Id(:remove),
             Opt(:hstretch),
-            "#{Yast::UI.Glyph} " + _("<- Remove")
+            "#{Yast::UI.Glyph(:ArrowLeft)} " + _("Remove")
           ),
           PushButton(
             Id(:remove_all),
             Opt(:hstretch),
-            "#{Yast::UI.Glyph} " + _("<- Remove All")
+            "#{Yast::UI.Glyph(:ArrowLeft)} " + _("Remove All")
           )
         ]
       end

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -52,7 +52,7 @@ module Y2Firewall
           HBox(
             VBox(
               Left(Label(_("Available"))),
-              available_svcs_table,
+              available_svcs_table
             ),
             VBox(*add_remove_buttons),
             VBox(
@@ -125,12 +125,12 @@ module Y2Firewall
           PushButton(
             Id(:add),
             Opt(:hstretch),
-            _("Add") + "#{Yast::UI.Glyph(:ArrowRight)}"
+            _("Add") + Yast::UI.Glyph(:ArrowRight).to_s
           ),
           PushButton(
             Id(:add_all),
             Opt(:hstretch),
-            _("Add All") + "#{Yast::UI.Glyph(:ArrowRight)}"
+            _("Add All") + Yast::UI.Glyph(:ArrowRight).to_s
           ),
           VSpacing(1),
           PushButton(

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -50,9 +50,15 @@ module Y2Firewall
 
         VBox(
           HBox(
-            available_svcs_table,
+            VBox(
+              Left(Label(_("Available"))),
+              available_svcs_table,
+            ),
             VBox(*add_remove_buttons),
-            allowed_svcs_table
+            VBox(
+              Left(Label(_("Allowed"))),
+              allowed_svcs_table
+            )
           )
         )
       end

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -34,7 +34,7 @@ module Y2Firewall
         textdomain "firewall"
         @zone = zone
         self.widget_id = "allowed_services"
-        @available_svcs_table = ServicesTable.new(widget_id: "available:#{zone.name}")
+        @known_svcs_table = ServicesTable.new(widget_id: "known:#{zone.name}")
         @allowed_svcs_table = ServicesTable.new(widget_id: "allowed:#{zone.name}")
         refresh_services
       end
@@ -51,8 +51,8 @@ module Y2Firewall
         VBox(
           HBox(
             VBox(
-              Left(Label(_("Available"))),
-              available_svcs_table
+              Left(Label(_("Known"))),
+              known_svcs_table
             ),
             VBox(*add_remove_buttons),
             VBox(
@@ -83,7 +83,7 @@ module Y2Firewall
 
     private
 
-      # @!attribute [r] available_svcs_table
+      # @!attribute [r] known_svcs_table
       #   @return [ServicesTable]
       #
       # @!attribute [r] allowed_svcs_table
@@ -91,11 +91,11 @@ module Y2Firewall
       #
       # @!attribute [r] zone
       #   @return [Y2Firewall::Firewalld::Zone]
-      attr_reader :available_svcs_table, :allowed_svcs_table, :zone
+      attr_reader :known_svcs_table, :allowed_svcs_table, :zone
 
       # Adds a service to the list of allowed ones
       def add_service
-        available_svcs_table.selected_services.each { |s| zone.add_service(s) }
+        known_svcs_table.selected_services.each { |s| zone.add_service(s) }
       end
 
       def add_all_services
@@ -113,7 +113,7 @@ module Y2Firewall
 
       # Refresh the content of the services tables
       def refresh_services
-        available_svcs_table.services = (firewall.current_service_names - zone.services)
+        known_svcs_table.services = (firewall.current_service_names - zone.services)
         allowed_svcs_table.services = zone.services.clone
       end
 

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -51,10 +51,7 @@ module Y2Firewall
         VBox(
           HBox(
             available_svcs_table,
-            VBox(
-              PushButton(Id(:add), _("Add")),
-              PushButton(Id(:remove), _("Remove"))
-            ),
+            VBox(*add_remove_buttons),
             allowed_svcs_table
           )
         )
@@ -62,11 +59,17 @@ module Y2Firewall
 
       # @macro seeAbstractWidget
       def handle(event)
+        return unless event["ID"]
+
         case event["ID"]
         when :add
           add_service
+        when :add_all
+          add_all_services
         when :remove
           remove_service
+        when :remove_all
+          remove_all_services
         end
         refresh_services
         nil
@@ -89,15 +92,52 @@ module Y2Firewall
         available_svcs_table.selected_services.each { |s| zone.add_service(s) }
       end
 
+      def add_all_services
+        firewall.current_service_names.each { |s| zone.add_service(s) }
+      end
+
       # Removes a service from the list of allowed ones
       def remove_service
         allowed_svcs_table.selected_services.each { |s| zone.remove_service(s) }
+      end
+
+      def remove_all_services
+        zone.services.clone.each { |s| zone.remove_service(s) }
       end
 
       # Refresh the content of the services tables
       def refresh_services
         available_svcs_table.update(firewall.current_service_names - zone.services)
         allowed_svcs_table.update(zone.services.clone)
+      end
+
+      # Return a list of buttons to add/remove elements
+      #
+      # @return [Array<Yast::Term>] Array containing add/remove buttons terms
+      def add_remove_buttons
+        [
+          PushButton(
+            Id(:add),
+            Opt(:hstretch),
+            _("Add") + "#{Yast::UI.Glyph(:ArrowRight)}"
+          ),
+          PushButton(
+            Id(:add_all),
+            Opt(:hstretch),
+            _("Add All") + "#{Yast::UI.Glyph(:ArrowRight)}"
+          ),
+          VSpacing(1),
+          PushButton(
+            Id(:remove),
+            Opt(:hstretch),
+            "#{Yast::UI.Glyph} " + _("<- Remove")
+          ),
+          PushButton(
+            Id(:remove_all),
+            Opt(:hstretch),
+            "#{Yast::UI.Glyph} " + _("<- Remove All")
+          )
+        ]
       end
 
       # Return the current `Y2Firewall::Firewalld` instance

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -107,13 +107,13 @@ module Y2Firewall
 
       # Refresh the content of the services tables
       def refresh_services
-        available_svcs_table.update(firewall.current_service_names - zone.services)
-        allowed_svcs_table.update(zone.services.clone)
+        available_svcs_table.services = (firewall.current_service_names - zone.services)
+        allowed_svcs_table.services = zone.services.clone
       end
 
       # Return a list of buttons to add/remove elements
       #
-      # @return [Array<Yast::Term>] Array containing add/remove buttons terms
+      # @return [Array<Yast::Term>] Buttons set UI terms
       def add_remove_buttons
         [
           PushButton(

--- a/src/lib/y2firewall/widgets/allowed_services.rb
+++ b/src/lib/y2firewall/widgets/allowed_services.rb
@@ -34,11 +34,17 @@ module Y2Firewall
         textdomain "firewall"
         @zone = zone
         self.widget_id = "allowed_services"
-        @available_svcs_table = ServicesTable.new
-        @allowed_svcs_table = ServicesTable.new
+        @available_svcs_table = ServicesTable.new(widget_id: "available:#{zone.name}")
+        @allowed_svcs_table = ServicesTable.new(widget_id: "allowed:#{zone.name}")
         refresh_services
       end
 
+      # @macro seeAbstractWidget
+      def label
+        _("Allowed Services")
+      end
+
+      # @macro seeCustomWidget
       def contents
         return @contents if @contents
 
@@ -54,6 +60,7 @@ module Y2Firewall
         )
       end
 
+      # @macro seeAbstractWidget
       def handle(event)
         case event["ID"]
         when :add
@@ -79,20 +86,25 @@ module Y2Firewall
 
       # Adds a service to the list of allowed ones
       def add_service
-        zone.add_service(available_svcs_table.selected_service)
+        available_svcs_table.selected_services.each { |s| zone.add_service(s) }
       end
 
       # Removes a service from the list of allowed ones
       def remove_service
-        zone.remove_service(allowed_svcs_table.selected_service)
+        allowed_svcs_table.selected_services.each { |s| zone.remove_service(s) }
       end
 
       # Refresh the content of the services tables
       def refresh_services
-        available_svcs_table.update(firewall.api.services - zone.services)
+        available_svcs_table.update(firewall.current_service_names - zone.services)
         allowed_svcs_table.update(zone.services.clone)
       end
 
+      # Return the current `Y2Firewall::Firewalld` instance
+      #
+      # This is just a convenience method.
+      #
+      # @return [Y2Firewall::Firewalld]
       def firewall
         Y2Firewall::Firewalld.instance
       end

--- a/src/lib/y2firewall/widgets/services_table.rb
+++ b/src/lib/y2firewall/widgets/services_table.rb
@@ -26,6 +26,14 @@ Yast.import "UI"
 
 module Y2Firewall
   module Widgets
+    # Table containing a set of firewalld services
+    #
+    # @example Creating a new table
+    #   names = Y2Firewall::Firewalld.instance.current_service_names
+    #   table = Y2Firewall::Widgets::Services.new(names)
+    #
+    # @example Updating content
+    #   table.services = ["dhcp", "dhcpv6", "dhcpv6-client"]
     class ServicesTable < ::CWM::Table
       # @!attribute [r] services
       #   @return [Array<String>] Services to be displayed
@@ -59,8 +67,10 @@ module Y2Firewall
 
       # Updates the list of services
       #
+      # @note When running on graphical mode, the new elements are kept selected.
+      #
       # @param services [Array<String>] New list of services
-      def update(services)
+      def services=(services)
         old_services = @services
         @services = services
         change_items(items)

--- a/src/lib/y2firewall/widgets/services_table.rb
+++ b/src/lib/y2firewall/widgets/services_table.rb
@@ -62,7 +62,7 @@ module Y2Firewall
 
       # @see CWM::Table#items
       def items
-        services.sort_by { |s| s.downcase }.map { |s| [s, s] }
+        services.sort_by(&:downcase).map { |s| [s, s] }
       end
 
       # Updates the list of services

--- a/src/lib/y2firewall/widgets/services_table.rb
+++ b/src/lib/y2firewall/widgets/services_table.rb
@@ -42,6 +42,7 @@ module Y2Firewall
         self.widget_id = widget_id || "services_table:#{object_id}"
       end
 
+      # @macro seeAbstractWidget
       def opt
         [:multiSelection]
       end

--- a/test/lib/y2firewall/widgets/allowed_services_test.rb
+++ b/test/lib/y2firewall/widgets/allowed_services_test.rb
@@ -55,7 +55,7 @@ describe Y2Firewall::Widgets::AllowedServices do
   before do
     allow(Y2Firewall::Firewalld).to receive(:instance).and_return(firewall)
     allow(Y2Firewall::Widgets::ServicesTable).to receive(:new)
-      .with(widget_id: "available:#{zone.name}").and_return(available_svcs_table)
+      .with(widget_id: "known:#{zone.name}").and_return(available_svcs_table)
     allow(Y2Firewall::Widgets::ServicesTable).to receive(:new)
       .with(widget_id: "allowed:#{zone.name}").and_return(allowed_svcs_table)
   end

--- a/test/lib/y2firewall/widgets/allowed_services_test.rb
+++ b/test/lib/y2firewall/widgets/allowed_services_test.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+
+require "cwm/rspec"
+require "y2firewall/widgets/allowed_services"
+
+describe Y2Firewall::Widgets::AllowedServices do
+  AVAILABLE_SERVICES = ["dhcp", "https", "ssh"].freeze
+
+  subject(:widget) { described_class.new(zone) }
+
+  let(:zone) do
+    Y2Firewall::Firewalld::Zone.new(name: "public").tap { |s| s.services = ["dhcp"] }
+  end
+
+  let(:firewall) do
+    instance_double(Y2Firewall::Firewalld, current_service_names: AVAILABLE_SERVICES)
+  end
+
+  let(:available_svcs_table) do
+    instance_double(Y2Firewall::Widgets::ServicesTable, update: nil, selected_service: "ssh")
+  end
+
+  let(:allowed_svcs_table) do
+    instance_double(Y2Firewall::Widgets::ServicesTable, update: nil, selected_service: "dhcp")
+  end
+
+  before do
+    allow(Y2Firewall::Firewalld).to receive(:instance).and_return(firewall)
+    allow(Y2Firewall::Widgets::ServicesTable).to receive(:new)
+      .with(widget_id: "available:#{zone.name}").and_return(available_svcs_table)
+    allow(Y2Firewall::Widgets::ServicesTable).to receive(:new)
+      .with(widget_id: "allowed:#{zone.name}").and_return(allowed_svcs_table)
+  end
+
+  include_examples "CWM::CustomWidget"
+
+  describe "#handle" do
+    context "adding a service to the list of allowed ones" do
+      let(:event) { {"ID" => :add} }
+
+      it "adds the selected service to the zone and updates both tables" do
+        expect(zone).to receive(:add_service).with("ssh").and_call_original
+        expect(allowed_svcs_table).to receive(:update).with(["dhcp", "ssh"])
+        expect(available_svcs_table).to receive(:update).with(["https"])
+
+        widget.handle(event)
+      end
+    end
+
+    context "removing a service from the list of allowed ones" do
+      let(:event) { {"ID" => :remove} }
+
+      it "removes the selected service from the zone and updates both tables" do
+        expect(zone).to receive(:remove_service).with("dhcp").and_call_original
+        expect(available_svcs_table).to receive(:update).with(["dhcp", "https", "ssh"])
+        expect(allowed_svcs_table).to receive(:update).with([])
+
+        widget.handle(event)
+      end
+    end
+  end
+end

--- a/test/lib/y2firewall/widgets/allowed_services_test.rb
+++ b/test/lib/y2firewall/widgets/allowed_services_test.rb
@@ -62,7 +62,7 @@ describe Y2Firewall::Widgets::AllowedServices do
 
   describe "#handle" do
     context "when it receives an event to add a service" do
-      let(:event) { {"ID" => :add} }
+      let(:event) { { "ID" => :add } }
 
       it "adds the selected service to the zone" do
         widget.handle(event)
@@ -77,7 +77,7 @@ describe Y2Firewall::Widgets::AllowedServices do
     end
 
     context "when it receives an event to remove a service" do
-      let(:event) { {"ID" => :remove} }
+      let(:event) { { "ID" => :remove } }
 
       it "removes the selected service from the zone" do
         widget.handle(event)
@@ -92,7 +92,7 @@ describe Y2Firewall::Widgets::AllowedServices do
     end
 
     context "when it receives an event to add all available services" do
-      let(:event) { {"ID" => :add_all} }
+      let(:event) { { "ID" => :add_all } }
 
       it "adds all services to the zone" do
         widget.handle(event)
@@ -107,7 +107,7 @@ describe Y2Firewall::Widgets::AllowedServices do
     end
 
     context "when it receives an event to remove all available services" do
-      let(:event) { {"ID" => :remove_all} }
+      let(:event) { { "ID" => :remove_all } }
 
       it "removes all services from the zone" do
         widget.handle(event)

--- a/test/lib/y2firewall/widgets/allowed_services_test.rb
+++ b/test/lib/y2firewall/widgets/allowed_services_test.rb
@@ -41,11 +41,15 @@ describe Y2Firewall::Widgets::AllowedServices do
   end
 
   let(:available_svcs_table) do
-    instance_double(Y2Firewall::Widgets::ServicesTable, update: nil, selected_services: ["ssh"])
+    instance_double(
+      Y2Firewall::Widgets::ServicesTable, :services= => nil, selected_services: ["ssh"]
+    )
   end
 
   let(:allowed_svcs_table) do
-    instance_double(Y2Firewall::Widgets::ServicesTable, update: nil, selected_services: ["dhcp"])
+    instance_double(
+      Y2Firewall::Widgets::ServicesTable, :services= => nil, selected_services: ["dhcp"]
+    )
   end
 
   before do
@@ -66,8 +70,8 @@ describe Y2Firewall::Widgets::AllowedServices do
       end
 
       it "updates services tables" do
-        expect(allowed_svcs_table).to receive(:update).with(["dhcp", "ssh"])
-        expect(available_svcs_table).to receive(:update).with(["https"])
+        expect(allowed_svcs_table).to receive(:services=).with(["dhcp", "ssh"])
+        expect(available_svcs_table).to receive(:services=).with(["https"])
         widget.handle(event)
       end
     end
@@ -81,8 +85,8 @@ describe Y2Firewall::Widgets::AllowedServices do
       end
 
       it "updates the services tables" do
-        expect(available_svcs_table).to receive(:update).with(["dhcp", "https", "ssh"])
-        expect(allowed_svcs_table).to receive(:update).with([])
+        expect(available_svcs_table).to receive(:services=).with(["dhcp", "https", "ssh"])
+        expect(allowed_svcs_table).to receive(:services=).with([])
         widget.handle(event)
       end
     end
@@ -96,8 +100,8 @@ describe Y2Firewall::Widgets::AllowedServices do
       end
 
       it "updates the services tables" do
-        expect(allowed_svcs_table).to receive(:update).with(AVAILABLE_SERVICES)
-        expect(available_svcs_table).to receive(:update).with([])
+        expect(allowed_svcs_table).to receive(:services=).with(AVAILABLE_SERVICES)
+        expect(available_svcs_table).to receive(:services=).with([])
         widget.handle(event)
       end
     end
@@ -111,8 +115,8 @@ describe Y2Firewall::Widgets::AllowedServices do
       end
 
       it "updates the services tables" do
-        expect(available_svcs_table).to receive(:update).with(AVAILABLE_SERVICES)
-        expect(allowed_svcs_table).to receive(:update).with([])
+        expect(available_svcs_table).to receive(:services=).with(AVAILABLE_SERVICES)
+        expect(allowed_svcs_table).to receive(:services=).with([])
         widget.handle(event)
       end
     end

--- a/test/lib/y2firewall/widgets/services_table_test.rb
+++ b/test/lib/y2firewall/widgets/services_table_test.rb
@@ -35,10 +35,11 @@ describe Y2Firewall::Widgets::ServicesTable do
       .and_return(["dhcp"])
   end
 
-  describe "#update" do
+  describe "#services" do
     it "updates the list of items" do
-      subject.update(["ssh"])
+      subject.services = ["ssh"]
       expect(widget.items).to eq([["ssh", "ssh"]])
+      expect(widget.services).to eq(["ssh"])
     end
 
     context "when some items are added" do
@@ -51,7 +52,7 @@ describe Y2Firewall::Widgets::ServicesTable do
 
         it "sets new items as selected" do
           expect(widget).to receive(:value=).with(["ssh"])
-          subject.update(["ssh"])
+          subject.services = ["ssh"]
         end
       end
 
@@ -60,7 +61,7 @@ describe Y2Firewall::Widgets::ServicesTable do
 
         it "does not set any item as selected" do
           expect(widget).to_not receive(:value=)
-          subject.update(["ssh"])
+          subject.services = ["ssh"]
         end
       end
     end

--- a/test/lib/y2firewall/widgets/services_table_test.rb
+++ b/test/lib/y2firewall/widgets/services_table_test.rb
@@ -26,6 +26,8 @@ require "cwm/rspec"
 require "y2firewall/widgets/services_table"
 
 describe Y2Firewall::Widgets::ServicesTable do
+  include_examples "CWM::CustomWidget"
+
   subject(:widget) { described_class.new(services: ["dhcp"], widget_id: "table") }
 
   before do
@@ -39,12 +41,12 @@ describe Y2Firewall::Widgets::ServicesTable do
       expect(widget.items).to eq([["ssh", "ssh"]])
     end
 
-    context "when some items are added in graphical mode" do
+    context "when some items are added" do
       before do
         allow(Yast::UI).to receive(:TextMode).and_return(textmode)
       end
 
-      context "and running in graphical mode" do
+      context "and YaST is running in graphical mode" do
         let(:textmode) { false }
 
         it "sets new items as selected" do
@@ -53,7 +55,7 @@ describe Y2Firewall::Widgets::ServicesTable do
         end
       end
 
-      context "and running in text mode" do
+      context "and YaST is running in text mode" do
         let(:textmode) { true }
 
         it "does not set any item as selected" do

--- a/test/lib/y2firewall/widgets/services_table_test.rb
+++ b/test/lib/y2firewall/widgets/services_table_test.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+
+require "cwm/rspec"
+require "y2firewall/widgets/services_table"
+
+describe Y2Firewall::Widgets::ServicesTable do
+  subject(:widget) { described_class.new(services: ["dhcp"], widget_id: "table") }
+
+  before do
+    allow(Yast::UI).to receive(:QueryWidget).with(Id("table"), :SelectedItems)
+      .and_return(["dhcp"])
+  end
+
+  describe "#update" do
+    it "updates the list of items" do
+      subject.update(["ssh"])
+      expect(widget.items).to eq([["ssh", "ssh"]])
+    end
+
+    context "when some items are added in graphical mode" do
+      before do
+        allow(Yast::UI).to receive(:TextMode).and_return(textmode)
+      end
+
+      context "and running in graphical mode" do
+        let(:textmode) { false }
+
+        it "sets new items as selected" do
+          expect(widget).to receive(:value=).with(["ssh"])
+          subject.update(["ssh"])
+        end
+      end
+
+      context "and running in text mode" do
+        let(:textmode) { true }
+
+        it "does not set any item as selected" do
+          expect(widget).to_not receive(:value=)
+          subject.update(["ssh"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR improves the *Allowed Services* tab and adds some unit tests.

![allowed-services-firewall-new](https://user-images.githubusercontent.com/15836/45421865-615a9780-b686-11e8-9b9f-e7de8451bad9.gif)




