### PR TITLE
Check and Install SuSEFirewall2 if selected as the firewall backend

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 25 12:19:40 UTC 2018 - knut.anderssen@suse.com
+
+- Checkt and install SuSEFirewall2 in case it is not installed when
+  selected as the firewall backend (bsc#1093052)
+- 3.2.1
+
+-------------------------------------------------------------------
 Wed Jun 14 07:37:51 UTC 2017 - mfilka@suse.com
 
 - bnc#1044045

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firewall.rb
+++ b/src/clients/firewall.rb
@@ -31,6 +31,7 @@
 #
 # File includes helps for yast2-firewall dialogs.
 #
+require "network/firewall_chooser"
 require "network/susefirewalld"
 
 module Yast
@@ -57,7 +58,7 @@ module Yast
       # there are some arguments - starting commandline
       if Ops.greater_than(Builtins.size(WFM.Args), 0)
         Yast.import "SuSEFirewallCMDLine"
-        SuSEFirewallCMDLine.Run 
+        SuSEFirewallCMDLine.Run
         # GUI or TextUI
       else
         # If FirewallD then use it's UI
@@ -79,6 +80,7 @@ module Yast
           if Mode.installation
             @ret = FirewallInstallationSequence()
           else
+            return false unless PackageSystem.CheckAndInstallPackages(["SuSEfirewall2"])
             @ret = FirewallSequence()
           end
         end
@@ -89,7 +91,7 @@ module Yast
       Builtins.y2milestone("Firewall module finished")
       Builtins.y2milestone("----------------------------------------")
 
-      deep_copy(@ret) 
+      deep_copy(@ret)
 
       # EOF
     end


### PR DESCRIPTION
We could improve the current client adding checks for obtaining the installed backends asking about which one to install when no one is present or which one should be configured when no one is active or  enabled, but at least now it tries to install the SuSEFirewall2 package when the backend is the fallback one.

- https://bugzilla.suse.com/show_bug.cgi?id=1093052
- It depends on https://github.com/yast/yast-yast2/pull/836