### PR TITLE
AutoYaST schema: New zone attributes (bsc#1108199)

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct  2 11:52:27 UTC 2018 - knut.anderssen@suse.com
+
+- AutoYast schema:
+  - Allowed the new 'description', 'short' and 'target' elements in
+    zone entries (bsc#1108199)
+- 4.0.28
+
+-------------------------------------------------------------------
 Fri Sep 21 13:26:02 UTC 2018 - igonzalezsosa@suse.com
 
 - Add a new user interface to manage firewalld configuration

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.27
+Version:        4.0.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/firewall.rnc
+++ b/src/autoyast-rnc/firewall.rnc
@@ -126,6 +126,9 @@ zones =
     LIST,
     element (zone | listentry) {
       zone_name &
+      zone_short? &
+      zone_description? &
+      zone_target? &
       fwd_interfaces? &
       fwd_services? &
       fwd_ports? &
@@ -166,6 +169,9 @@ fwd_sources =
   }
 
 zone_name = element name { text }
+zone_short = element short { text }
+zone_description = element description { text }
+zone_target = element target { text }
 default_zone = element default_zone { text }
 masquerade = element masquerade { BOOLEAN }
 log_denied_packets = element log_denied_packets { text }


### PR DESCRIPTION
In this [commit](https://github.com/yast/yast-yast2/pull/818/files#diff-1b7047b35ed0976769eccd6200a38d82R56) we added support for more zone attributes  but we forgot to update the firewall schema.

This PR fix it.

- https://bugzilla.suse.com/show_bug.cgi?id=1108199
