### PR TITLE
Added missing requirement

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 17 10:48:42 UTC 2018 - knut.anderssen@suse.com
+
+- Added missing interfaces helpers requirement (fate#324662)
+- 4.0.33
+
+-------------------------------------------------------------------
 Tue Oct 16 20:34:32 UTC 2018 - knut.anderssen@suse.com
 
 - Fixed zone_options widget test mocking (fate#324662)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.32
+Version:        4.0.33
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firewall/widgets/pages/zones.rb
+++ b/src/lib/y2firewall/widgets/pages/zones.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "cwm/page"
 require "y2firewall/firewalld"
+require "y2firewall/helpers/interfaces"
 require "y2firewall/widgets/zones_table"
 require "y2firewall/widgets/default_zone_button"
 


### PR DESCRIPTION
The test for the page fails if run isolated or before the overview dialog test.

see: https://build.opensuse.org/request/show/642595

Tested running all the test with:

`find test/lib -iname "*_test.rb" -exec rspec --color --format doc {} \;`