### PR TITLE
Enable and open SSH port when authentication is done via public key

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  2 10:04:07 UTC 2018 - igonzalezsosa@suse.com
+
+- Enable and open the SSH port when only public key authentication
+  is available for the root user (fate#324690).
+- 4.0.34
+
+-------------------------------------------------------------------
 Wed Oct 17 10:48:42 UTC 2018 - knut.anderssen@suse.com
 
 - Added missing interfaces helpers requirement (fate#324662)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -32,13 +32,9 @@ BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2 >= 4.1.21
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
-# Yast::UsersSimple.GetRootPassword
-BuildRequires:  yast2-users
 
 # Y2Firewall::Firewalld#reset
 Requires:       yast2 >= 4.1.21
-# Yast::UsersSimple.GetRootPassword
-Requires:       yast2-users
 
 # ButtonBox widget
 Conflicts:	yast2-ycp-ui-bindings < 2.17.3

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -32,9 +32,13 @@ BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2 >= 4.1.21
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
+# Yast::UsersSimple.GetRootPassword
+BuildRequires:  yast2-users
 
 # Y2Firewall::Firewalld#reset
 Requires:       yast2 >= 4.1.21
+# Yast::UsersSimple.GetRootPassword
+Requires:       yast2-users
 
 # ButtonBox widget
 Conflicts:	yast2-ycp-ui-bindings < 2.17.3

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.0.33
+Version:        4.0.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firewall/proposal_settings.rb
+++ b/src/lib/y2firewall/proposal_settings.rb
@@ -21,6 +21,8 @@
 
 require "yast"
 
+Yast.import "UsersSimple"
+
 module Y2Firewall
   # Class that stores the proposal settings for firewalld during installation.
   class ProposalSettings
@@ -46,8 +48,8 @@ module Y2Firewall
 
       load_features
       enable_firewall! if @enable_firewall
-      enable_sshd! if Yast::Linuxrc.usessh || @enable_sshd
-      open_ssh! if Yast::Linuxrc.usessh || @open_ssh
+      enable_sshd! if Yast::Linuxrc.usessh || only_public_key_auth || @enable_sshd
+      open_ssh! if Yast::Linuxrc.usessh || only_public_key_auth || @open_ssh
       open_vnc! if Yast::Linuxrc.vnc
       # FIXME: obtain from Y2Firewall::Firewalld, control file or allow to
       # chose a different one in the proposal
@@ -129,6 +131,15 @@ module Y2Firewall
 
     def global_section
       Yast::ProductFeatures.GetSection("globals")
+    end
+
+    # Determines whether only public key authentication is supported
+    #
+    # @note If the root user does not have a password, we assume that we will use a public
+    #   key in order to log into the system. In such a case, we need to enable the SSH
+    #   service (including opening the port).
+    def only_public_key_auth
+      Yast::UsersSimple.GetRootPassword.empty?
     end
 
     class << self

--- a/src/lib/y2firewall/proposal_settings.rb
+++ b/src/lib/y2firewall/proposal_settings.rb
@@ -48,9 +48,9 @@ module Y2Firewall
 
       load_features
       enable_firewall! if @enable_firewall
-      enable_sshd! if Yast::Linuxrc.usessh || only_public_key_auth || @enable_sshd
-      open_ssh! if Yast::Linuxrc.usessh || only_public_key_auth || @open_ssh
-      open_vnc! if Yast::Linuxrc.vnc
+      enable_sshd! if wanted_enable_sshd?
+      open_ssh! if wanted_open_ssh?
+      open_vnc! if wanted_open_vnc?
       # FIXME: obtain from Y2Firewall::Firewalld, control file or allow to
       # chose a different one in the proposal
       @default_zone = "public"
@@ -131,6 +131,18 @@ module Y2Firewall
 
     def global_section
       Yast::ProductFeatures.GetSection("globals")
+    end
+
+    def wanted_enable_sshd?
+      Yast::Linuxrc.usessh || only_public_key_auth || @enable_sshd
+    end
+
+    def wanted_open_ssh?
+      Yast::Linuxrc.usessh || only_public_key_auth || @open_ssh
+    end
+
+    def wanted_open_vnc?
+      Yast::Linuxrc.vnc
     end
 
     # Determines whether only public key authentication is supported

--- a/test/lib/y2firewall/proposal_settings_test.rb
+++ b/test/lib/y2firewall/proposal_settings_test.rb
@@ -36,10 +36,12 @@ describe Y2Firewall::ProposalSettings do
   end
   let(:use_vnc) { false }
   let(:use_ssh) { false }
+  let(:root_password) { "secret" }
 
   before do
     allow(Yast::Linuxrc).to receive(:vnc).and_return(use_vnc)
     allow(Yast::Linuxrc).to receive(:usessh).and_return(use_ssh)
+    allow(Yast::UsersSimple).to receive(:GetRootPassword).and_return(root_password)
 
     allow(Yast::ProductFeatures).to receive("GetSection")
       .with("globals").and_return(global_section)
@@ -83,6 +85,21 @@ describe Y2Firewall::ProposalSettings do
 
       it "sets the vnc port to be opened" do
         expect_any_instance_of(described_class).to receive(:open_vnc!)
+
+        described_class.create_instance
+      end
+    end
+
+    context "when no root password was set" do
+      before do
+        allow(Yast::Linuxrc).to receive(:usessh).and_return(false)
+        allow(Yast::UsersSimple).to receive(:GetRootPassword)
+          .and_return("")
+      end
+
+      it "opens SSH to allow public key authentication" do
+        expect_any_instance_of(described_class).to receive(:enable_sshd!)
+        expect_any_instance_of(described_class).to receive(:open_ssh!)
 
         described_class.create_instance
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,12 +29,14 @@ require "yast/rspec"
 
 # stub module to prevent its Import
 # Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name)
-  Yast.const_set name.to_sym, Class.new { def self.fake_method; end }
+def stub_module(name, fake_class = nil)
+  fake_class = Class.new { def self.fake_method; end } if fake_class.nil?
+  Yast.const_set name.to_sym, fake_class
 end
 
 # stub classes from other modules to speed up a build
 stub_module("AutoInstall")
+stub_module("UsersSimple", Class.new { def self.GetRootPassword; "secret"; end })
 
 # some tests have translatable messages
 ENV["LANG"] = "en_US.UTF-8"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,8 @@ end
 
 # stub classes from other modules to speed up a build
 stub_module("AutoInstall")
+# rubocop:disable Style/SingleLineMethods
+# rubocop:disable Style/MethodName
 stub_module("UsersSimple", Class.new { def self.GetRootPassword; "secret"; end })
 
 # some tests have translatable messages


### PR DESCRIPTION
When no password but an SSH public key has been specified in the installation for the root user,
YaST proposes to open the SSH service in order to allow logging into the system.

See https://github.com/yast/yast-users/pull/173