### PR TITLE
Added new zone elements to the AY schema

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan  8 08:53:09 UTC 2019 - knut.anderssen@suse.com
+
+- AutoYast schema:
+  - Allowed the new 'forward_ports', 'rich_rules' and
+    'source_ports' elements in zone entries (bsc#1108199)
+- 4.1.4
+
+-------------------------------------------------------------------
 Thu Dec 20 11:19:51 UTC 2018 - knut.anderssen@suse.com
 
 - Startup dialog: Replace the old UI::ServiceStatus by the new

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/firewall.rnc
+++ b/src/autoyast-rnc/firewall.rnc
@@ -129,10 +129,13 @@ zones =
       zone_short? &
       zone_description? &
       zone_target? &
+      fwd_forward_ports? &
       fwd_interfaces? &
-      fwd_services? &
       fwd_ports? &
       fwd_protocols? &
+      fwd_rich_rules? &
+      fwd_services? &
+      fwd_source_ports? &
       fwd_sources? &
       masquerade?
     }*
@@ -166,6 +169,24 @@ fwd_sources =
   element sources {
     LIST,
     element (source | listentry) {text}*
+  }
+
+fwd_rich_rules =
+  element rich_rules {
+    LIST,
+    element (rich_rule | litentry) {text}*
+  }
+
+fwd_source_ports =
+  element source_ports {
+    LIST,
+    element (souce_port | litentry) {text}*
+  }
+
+fwd_forward_ports =
+  element forward_ports {
+    LIST,
+    element (forward_port | litentry) {text}*
   }
 
 zone_name = element name { text }


### PR DESCRIPTION
The zone elements added are:

  - rich_rules
  - source_ports
  - forward_ports

See ([bsc#1108199](https://bugzilla.suse.com/show_bug.cgi?id=1108199)).

These changes were added by this [PR](https://github.com/yast/yast-yast2/pull/807/files#diff-5f18f6aba33e047bd40791544760f288R51)