### PR TITLE
require yast2 >= 3.2.49 to ensure we have firewall_chooser (bsc#1121627)

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 14 12:58:15 UTC 2019 - snwint@suse.com
+
+- adjust package requires to ensure firewall_chooser exists (bsc#1121627)
+- 3.2.2
+
+-------------------------------------------------------------------
 Tue Sep 25 12:19:40 UTC 2018 - knut.anderssen@suse.com
 
 - Checkt and install SuSEFirewall2 in case it is not installed when

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -30,8 +30,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 # IP::CheckNetwork
 BuildRequires:	yast2 >= 2.23.25
 
-# FirewallD backend
-Requires:	yast2 >= 3.1.191
+# network/firewall_chooser needed
+Requires:       yast2 >= 3.2.49
 
 # ButtonBox widget
 Conflicts:	yast2-ycp-ui-bindings < 2.17.3


### PR DESCRIPTION
Note that this version number is *different* than for SLE12-SP3. What a
versioning mess. :-(