### PR TITLE
AY Config: Fixed issues with importation and configuration changes 

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 23 09:52:51 UTC 2019 - knut.anderssen@suse.com
+
+- Autoyast: do not overwrite imported configuration when editing
+  and fixed check for not configured summary (fate#324662)
+- 4.1.10
+
+-------------------------------------------------------------------
 Thu Jan 17 12:53:20 UTC 2019 - knut.anderssen@suse.com
 
 - Propose to reload the firewalld service after writing instead of

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.1.9
+Version:        4.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2firewall/dialogs/main.rb
+++ b/src/lib/y2firewall/dialogs/main.rb
@@ -36,9 +36,7 @@ module Y2Firewall
         Yast.import "NetworkInterfaces"
         textdomain "firewall"
 
-        if Yast::Mode.config
-          fw.read(minimal: true) unless fw.read?
-        else
+        unless Yast::Mode.config
           Yast::NetworkInterfaces.Read
           fw.read unless fw.read?
         end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/5OWTqVV4/594-fate-324662-sle-15-sp1-yast-module-for-firewalld-supercard)
- [Fate#324662](https://fate.suse.com/324662)

This PR fixes these issues found by @jreidinger in AY config mode:

- [X] start autoyast config, import autoyast profile -> It prints firewall is not configured
- [X] start autoyast config, import autoyast profile, Edit -> it uses empty profile and not imported one for editing
- [X] start autoyast config, klone system, define custom zone and accept -> custom zone is not print by presenter ( not sure why )

