### PR TITLE
Mode autoyast

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Wed Feb 26 20:23:04 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
-- Autoyast: Added back the installation finish client for opening
-  the vnc or ssh port during the first stage when used for remote
+- AutoYaST: Added back the installation finish client for opening
+  the VNC or SSH port during the first stage when used for remote
   installations (bsc#1161319)
 - 4.2.3
 

--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 26 20:23:04 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Autoyast: Added back the installation finish client for opening
+  the vnc or ssh port during the first stage when used for remote
+  installations (bsc#1161319)
+- 4.2.3
+
+-------------------------------------------------------------------
 Tue Aug 27 18:00:06 CEST 2019 - schubi@suse.de
 
 - Set X-SuSE-YaST-AutoInstResource in desktop file (bsc#144894).

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -24,6 +24,8 @@ require "y2firewall/firewalld"
 require "y2firewall/proposal_settings"
 require "installation/finish_client"
 
+Yast.import "Mode"
+
 module Y2Firewall
   module Clients
     # This is a step of base installation finish and it is responsible of write
@@ -49,7 +51,7 @@ module Y2Firewall
       end
 
       def modes
-        [:installation]
+        [:installation, :autoinst]
       end
 
       def write
@@ -63,7 +65,9 @@ module Y2Firewall
       # Modifies the configuration of the firewall according to the current
       # settings
       def configure_firewall
-        @settings.enable_firewall ? @firewalld.enable! : @firewalld.disable!
+        if Yast::Mode.installation
+          @settings.enable_firewall ? @firewalld.enable! : @firewalld.disable!
+        end
 
         if @settings.open_ssh
           @firewalld.api.add_service(@settings.default_zone, "ssh")

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -65,16 +65,32 @@ module Y2Firewall
       # Modifies the configuration of the firewall according to the current
       # settings
       def configure_firewall
-        if Yast::Mode.installation
-          @settings.enable_firewall ? @firewalld.enable! : @firewalld.disable!
-        end
+        configure_service
+        configure_ssh
+        configure_vnc
+      end
 
+      # Convenience method to enable / disable the firewalld service depending
+      # on the proposal settings
+      def configure_service
+        return unless Yast::Mode.installation
+
+        @settings.enable_firewall ? @firewalld.enable! : @firewalld.disable!
+      end
+
+      # Convenience method to open the ssh ports in firewalld depending on the
+      # proposal settings
+      def configure_ssh
         if @settings.open_ssh
           @firewalld.api.add_service(@settings.default_zone, "ssh")
         else
           @firewalld.api.remove_service(@settings.default_zone, "ssh")
         end
+      end
 
+      # Convenience method to open the vnc ports in firewalld depending on the
+      # proposal settings
+      def configure_vnc
         if @settings.open_vnc
           if @firewalld.api.service_supported?("tigervnc")
             @firewalld.api.add_service(@settings.default_zone, "tigervnc")

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -65,14 +65,14 @@ module Y2Firewall
       # Modifies the configuration of the firewall according to the current
       # settings
       def configure_firewall
-        configure_service
+        configure_firewall_service
         configure_ssh
         configure_vnc
       end
 
       # Convenience method to enable / disable the firewalld service depending
       # on the proposal settings
-      def configure_service
+      def configure_firewall_service
         return unless Yast::Mode.installation
 
         @settings.enable_firewall ? @firewalld.enable! : @firewalld.disable!

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -399,4 +399,10 @@ describe Y2Firewall::Clients::Auto do
       end
     end
   end
+
+  describe "#packages" do
+    it "returns a hash with firewalld as a package to be installed" do
+      expect(subject.packages).to eq("install" => ["firewalld"], "remove" => [])
+    end
+  end
 end

--- a/test/lib/y2firewall/clients/installation_finish_test.rb
+++ b/test/lib/y2firewall/clients/installation_finish_test.rb
@@ -21,7 +21,7 @@ describe Y2Firewall::Clients::InstallationFinish do
 
   describe "#modes" do
     it "runs on installation and autoinstallation" do
-      expect(subject.modes).to eq([:installation])
+      expect(subject.modes).to eq([:installation, :autoinst])
     end
   end
 
@@ -69,26 +69,30 @@ describe Y2Firewall::Clients::InstallationFinish do
     let(:api) do
       instance_double(Y2Firewall::Firewalld::Api, remove_service: true, add_service: true)
     end
+    let(:installation) { true }
 
     before do
       allow(proposal_settings).to receive("enable_firewall").and_return(enable_firewall)
       allow(firewalld).to receive("api").and_return(api)
       allow(firewalld).to receive("enable!")
       allow(firewalld).to receive("disable!")
+      allow(Yast::Mode).to receive(:installation).and_return(installation)
       allow(proposal_settings).to receive("open_ssh").and_return(false)
     end
 
-    it "enables the firewalld service if enabled in the proposal" do
-      allow(proposal_settings).to receive("enable_firewall").and_return(true)
-      expect(firewalld).to receive("enable!")
+    context "during an installation" do
+      it "enables the firewalld service if enabled in the proposal" do
+        allow(proposal_settings).to receive("enable_firewall").and_return(true)
+        expect(firewalld).to receive("enable!")
 
-      subject.send(:configure_firewall)
-    end
+        subject.send(:configure_firewall)
+      end
 
-    it "disables the firewalld service if disabled in the proposal" do
-      expect(firewalld).to receive("disable!")
+      it "disables the firewalld service if disabled in the proposal" do
+        expect(firewalld).to receive("disable!")
 
-      subject.send(:configure_firewall)
+        subject.send(:configure_firewall)
+      end
     end
 
     it "adds the ssh service to the default zone if opened in the proposal" do

--- a/test/lib/y2firewall/clients/installation_finish_test.rb
+++ b/test/lib/y2firewall/clients/installation_finish_test.rb
@@ -30,13 +30,13 @@ describe Y2Firewall::Clients::InstallationFinish do
     let(:installed) { true }
 
     before do
-      allow(proposal_settings).to receive("enable_sshd").and_return(enable_sshd)
-      allow(firewalld).to receive("installed?").and_return(installed)
-      allow(proposal_settings).to receive("open_ssh").and_return(false)
+      allow(proposal_settings).to receive(:enable_sshd).and_return(enable_sshd)
+      allow(firewalld).to receive(:installed?).and_return(installed)
+      allow(proposal_settings).to receive(:open_ssh).and_return(false)
     end
 
     it "enables the sshd service if enabled in the proposal" do
-      allow(proposal_settings).to receive("enable_sshd").and_return(true)
+      allow(proposal_settings).to receive(:enable_sshd).and_return(true)
       expect(Yast::Service).to receive(:Enable).with("sshd")
 
       subject.write
@@ -72,31 +72,31 @@ describe Y2Firewall::Clients::InstallationFinish do
     let(:installation) { true }
 
     before do
-      allow(proposal_settings).to receive("enable_firewall").and_return(enable_firewall)
-      allow(firewalld).to receive("api").and_return(api)
-      allow(firewalld).to receive("enable!")
-      allow(firewalld).to receive("disable!")
+      allow(proposal_settings).to receive(:enable_firewall).and_return(enable_firewall)
+      allow(firewalld).to receive(:api).and_return(api)
+      allow(firewalld).to receive(:enable!)
+      allow(firewalld).to receive(:disable!)
       allow(Yast::Mode).to receive(:installation).and_return(installation)
-      allow(proposal_settings).to receive("open_ssh").and_return(false)
+      allow(proposal_settings).to receive(:open_ssh).and_return(false)
     end
 
     context "during an installation" do
       it "enables the firewalld service if enabled in the proposal" do
-        allow(proposal_settings).to receive("enable_firewall").and_return(true)
-        expect(firewalld).to receive("enable!")
+        allow(proposal_settings).to receive(:enable_firewall).and_return(true)
+        expect(firewalld).to receive(:enable!)
 
         subject.send(:configure_firewall)
       end
 
       it "disables the firewalld service if disabled in the proposal" do
-        expect(firewalld).to receive("disable!")
+        expect(firewalld).to receive(:disable!)
 
         subject.send(:configure_firewall)
       end
     end
 
     it "adds the ssh service to the default zone if opened in the proposal" do
-      expect(proposal_settings).to receive("open_ssh").and_return(true)
+      expect(proposal_settings).to receive(:open_ssh).and_return(true)
       expect(api).to receive(:add_service).with(proposal_settings.default_zone, "ssh")
 
       subject.send(:configure_firewall)
@@ -112,7 +112,7 @@ describe Y2Firewall::Clients::InstallationFinish do
       let(:service_available) { true }
 
       before do
-        allow(proposal_settings).to receive("open_vnc").and_return(true)
+        allow(proposal_settings).to receive(:open_vnc).and_return(true)
         allow(api).to receive(:service_supported?).with("tigervnc").and_return(service_available)
       end
 


### PR DESCRIPTION
## Problem

In case of an autoinstallation with **VNC**, the server is not reachable during the second stage.

- https://trello.com/c/thlto0ec/1610-5-sles15-sp2-p2-1161319-build-1261-vnc-is-not-reachable-for-second-stage-during-autoyast-installation-on-zkvm

## Solution

Bring back the firewall installation finish client which opens the **VNC** or **SSH** server ports if firewalld is installed and the installation is done remotely through **VNC** or **SSH**.

## Test

- Tested manually