### PR TITLE
Force a reset of the firewalld API instance (bsc#1166698)

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Mar 21 12:02:05 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Force a reset of the firewalld API instance after modifying the
+  service state (bsc#1166698)
+- 4.2.4
+
+-------------------------------------------------------------------
 Wed Feb 26 20:23:04 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: Added back the installation finish client for opening

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -133,6 +133,8 @@ module Y2Firewall
           import(self.class.profile, false)
         else
           activate_service
+          # Force a reset of the API instance (bsc#1166698)
+          firewalld.api = nil
         end
       end
 


### PR DESCRIPTION
## Problem

**firewalld auto** client runs before the **tftp server** one modifying the firewalld service state. The problem is that the firewalld **API** instance is cached and thus, the tftp server uses the **online cmd** instead of the **offline**.

- https://trello.com/c/oKLCTb39/1719-3-sle15-sp2-1166698-ay-failed-at-tftpserverauto-with-error-firewalld-not-working
- https://bugzilla.suse.com/show_bug.cgi?id=1166698

## Solution

- Force a reset of the firewalld API instance after modifying the service state.

## Screenshots

<details>
  <summary>Before the fix</summary>

![Screenshot_testing_2020-03-21_10:47:59](https://user-images.githubusercontent.com/7056681/77226599-7b294480-6b71-11ea-93d1-a9721c014da3.png)
</details>
<details>
  <summary>After the fix</summary>

![Screenshot_testing_2020-03-21_11:13:59](https://user-images.githubusercontent.com/7056681/77226601-7cf30800-6b71-11ea-9666-3e70977d2e81.png)
</details>


