### PR TITLE
Remove CONTRIBUTING.md from the spec file

### DIFF
--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -74,4 +74,3 @@ A YaST2 module to be used for configuring a firewall.
 %{yast_icondir}
 %license COPYING
 %doc README.md
-%doc CONTRIBUTING.md


### PR DESCRIPTION
## Problem

The **CONTRIBUTING.md** file was removed (#129) from the repository but the file is still referenced in the spec file

## Solution

Remove the file from the spec file
