### PR TITLE
Cleanup issue and profile handling

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  7 15:22:56 CEST 2020 - schubi@suse.de
+
+- AutoYaST: Cleanup/improve issue handling (bsc#1171335).
+- 4.2.5
+
+-------------------------------------------------------------------
 Sat Mar 21 12:02:05 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Force a reset of the firewalld API instance after modifying the

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -29,12 +29,12 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 4.2.2
 # AutoYaST issue report
-BuildRequires:  yast2 >= 4.2.84
+BuildRequires:  yast2 >= 4.3.2
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
 # AutoYaST issue report
-Requires:       yast2 >= 4.2.84
+Requires:       yast2 >= 4.3.2
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 # ButtonBox widget

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -28,13 +28,13 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 4.2.2
-# Removed zone name from common attributes definition
-BuildRequires:  yast2 >= 4.1.67
+# AutoYaST issue report
+BuildRequires:  yast2 >= 4.2.84
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
-# Removed zone name from common attributes definition
-Requires:       yast2 >= 4.1.67
+# AutoYaST issue report
+Requires:       yast2 >= 4.2.84
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 # ButtonBox widget

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/autoinst_profile/firewall_section.rb
+++ b/src/lib/y2firewall/autoinst_profile/firewall_section.rb
@@ -24,13 +24,12 @@ module Y2Firewall
     # This class represents an AutoYaST \<firewall> section
 
     class FirewallSection < ::Installation::AutoinstProfile::SectionWithAttributes
-      
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).
       #
       # @param hash [Hash] Firewall section from an AutoYaST profile
       # @return [FirewallSection]
-      def self.new_from_hashes(hash)
+      def self.new_from_hashes(_hash)
         result = new
         result
       end

--- a/src/lib/y2firewall/autoinst_profile/firewall_section.rb
+++ b/src/lib/y2firewall/autoinst_profile/firewall_section.rb
@@ -1,0 +1,39 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "installation/autoinst_profile/section_with_attributes"
+
+module Y2Firewall
+  module AutoinstProfile
+    # This class represents an AutoYaST \<firewall> section
+
+    class FirewallSection < ::Installation::AutoinstProfile::SectionWithAttributes
+      
+      # Creates an instance based on the profile representation used by the AutoYaST modules
+      # (hash with nested hashes and arrays).
+      #
+      # @param hash [Hash] Firewall section from an AutoYaST profile
+      # @return [FirewallSection]
+      def self.new_from_hashes(hash)
+        result = new
+        result
+      end
+    end
+  end
+end

--- a/src/lib/y2firewall/autoinst_profile/firewall_section.rb
+++ b/src/lib/y2firewall/autoinst_profile/firewall_section.rb
@@ -22,7 +22,7 @@ require "installation/autoinst_profile/section_with_attributes"
 module Y2Firewall
   module AutoinstProfile
     # This class represents an AutoYaST \<firewall> section
-
+    #
     class FirewallSection < ::Installation::AutoinstProfile::SectionWithAttributes
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).

--- a/src/lib/y2firewall/autoinst_profile/firewall_section.rb
+++ b/src/lib/y2firewall/autoinst_profile/firewall_section.rb
@@ -21,7 +21,7 @@ require "installation/autoinst_profile/section_with_attributes"
 
 module Y2Firewall
   module AutoinstProfile
-    # This class represents an AutoYaST \<firewall> section
+    # This class represents an AutoYaST <firewall> section
     #
     class FirewallSection < ::Installation::AutoinstProfile::SectionWithAttributes
       # Creates an instance based on the profile representation used by the AutoYaST modules

--- a/src/lib/y2firewall/autoinst_profile/firewall_section.rb
+++ b/src/lib/y2firewall/autoinst_profile/firewall_section.rb
@@ -27,7 +27,7 @@ module Y2Firewall
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).
       #
-      # @param hash [Hash] Firewall section from an AutoYaST profile
+      # @param _hash [Hash] Firewall section from an AutoYaST profile
       # @return [FirewallSection]
       def self.new_from_hashes(_hash)
         result = new

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -201,13 +201,15 @@ module Y2Firewall
         all_interfaces = zones.flat_map { |zone| zone["interfaces"] || [] }
         double_entries = all_interfaces.select { |i| all_interfaces.count(i) > 1 }.uniq
         unless double_entries.empty?
-          AutoInstall.issues_list.add(:ay_invalid_value,
+          AutoInstall.issues_list.add(
+            ::Installation::AutoinstIssues::AyInvalidValue,
             Y2Firewall::AutoinstProfile::FirewallSection.new_from_hashes(
               self.class.profile
             ),
             "interfaces",
             double_entries.join(","),
-            _("This interface has been defined for more than one zone."))
+            _("This interface has been defined for more than one zone.")
+          )
         end
       end
 

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -202,7 +202,7 @@ module Y2Firewall
         double_entries = all_interfaces.select { |i| all_interfaces.count(i) > 1 }.uniq
         unless double_entries.empty?
           AutoInstall.issues_list.add(
-            ::Installation::AutoinstIssues::AyInvalidValue,
+            ::Installation::AutoinstIssues::InvalidValue,
             Y2Firewall::AutoinstProfile::FirewallSection.new_from_hashes(
               self.class.profile
             ),

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -25,6 +25,7 @@ require "y2firewall/autoyast"
 require "y2firewall/proposal_settings"
 require "y2firewall/summary_presenter"
 require "y2firewall/dialogs/main"
+require "y2firewall/autoinst_profile/firewall_section"
 require "installation/auto_client"
 
 Yast.import "Mode"
@@ -200,7 +201,10 @@ module Y2Firewall
         all_interfaces = zones.flat_map { |zone| zone["interfaces"] || [] }
         double_entries = all_interfaces.select { |i| all_interfaces.count(i) > 1 }.uniq
         unless double_entries.empty?
-          AutoInstall.issues_list.add(:invalid_value, "firewall", "interfaces",
+          AutoInstall.issues_list.add(:ay_invalid_value,
+            Y2Firewall::AutoinstProfile::FirewallSection.new_from_hashes(
+              self.class.profile),
+            "interfaces",
             double_entries.join(","),
             _("This interface has been defined for more than one zone."))
         end

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -203,7 +203,8 @@ module Y2Firewall
         unless double_entries.empty?
           AutoInstall.issues_list.add(:ay_invalid_value,
             Y2Firewall::AutoinstProfile::FirewallSection.new_from_hashes(
-              self.class.profile),
+              self.class.profile
+            ),
             "interfaces",
             double_entries.join(","),
             _("This interface has been defined for more than one zone."))

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -191,7 +191,7 @@ describe Y2Firewall::Clients::Auto do
           .and_return("zones" => [{ "interfaces" => ["eth0"], "name" => "public" },
                                   { "interfaces" => ["eth0", "eth0"], "name" => "trusted" }])
         expect(i_list).to receive(:add)
-          .with(::Installation::AutoinstIssues::AyInvalidValue,
+          .with(::Installation::AutoinstIssues::InvalidValue,
             "firewall", "interfaces",
             "eth0",
             "This interface has been defined for more than one zone.")

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -22,6 +22,7 @@
 require_relative "../../../test_helper"
 require "y2firewall/dialogs/main"
 require "y2firewall/clients/auto"
+require "installation/autoinst_issues"
 
 describe Y2Firewall::Clients::Auto do
   let(:firewalld) { Y2Firewall::Firewalld.instance }
@@ -171,6 +172,14 @@ describe Y2Firewall::Clients::Auto do
     end
 
     context "once the current configuration has been set" do
+
+      let(:fw_section) { Y2Firewall::AutoinstProfile::FirewallSection.new }
+
+      before do
+        allow(Y2Firewall::AutoinstProfile::FirewallSection).to receive(:new_from_hashes)
+          .and_return(fw_section)
+      end
+
       it "imports the given profile" do
         expect(autoyast).to receive(:import).with(arguments)
 
@@ -192,7 +201,7 @@ describe Y2Firewall::Clients::Auto do
                                   { "interfaces" => ["eth0", "eth0"], "name" => "trusted" }])
         expect(i_list).to receive(:add)
           .with(::Installation::AutoinstIssues::InvalidValue,
-            "firewall", "interfaces",
+            fw_section, "interfaces",
             "eth0",
             "This interface has been defined for more than one zone.")
         subject.import(arguments, false)

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -191,7 +191,7 @@ describe Y2Firewall::Clients::Auto do
           .and_return("zones" => [{ "interfaces" => ["eth0"], "name" => "public" },
                                   { "interfaces" => ["eth0", "eth0"], "name" => "trusted" }])
         expect(i_list).to receive(:add)
-          .with(:invalid_value, "firewall", "interfaces",
+          .with(:ay_invalid_value, "firewall", "interfaces",
             "eth0",
             "This interface has been defined for more than one zone.")
         subject.import(arguments, false)

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -191,7 +191,8 @@ describe Y2Firewall::Clients::Auto do
           .and_return("zones" => [{ "interfaces" => ["eth0"], "name" => "public" },
                                   { "interfaces" => ["eth0", "eth0"], "name" => "trusted" }])
         expect(i_list).to receive(:add)
-          .with(:ay_invalid_value, "firewall", "interfaces",
+          .with(::Installation::AutoinstIssues::AyInvalidValue,
+            "firewall", "interfaces",
             "eth0",
             "This interface has been defined for more than one zone.")
         subject.import(arguments, false)


### PR DESCRIPTION
Problem
=========

Each module (storage, firewall,network) has his own AutoYaST Issue and profile handling which is incompatible and doubles the code.
bsc#1171335

Solution
=========

Bring base classes to yast2 package and cleanup the code of the other packages which will use
these common base classes:
yast/yast-yast2#1050
https://github.com/yast/yast-yast2/pull/1055