### PR TITLE
Run autoyast configuration in the first stage

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  2 10:23:06 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- AutoYaST: moved the configuration into first stage
+- 4.3.2
+
+-------------------------------------------------------------------
 Thu May  7 15:22:56 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Cleanup/improve issue handling (bsc#1171335).

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -82,7 +82,6 @@ module Y2Firewall
       # @return [Boolean]
       def import(profile, merge = !Yast::Mode.config)
         self.class.profile = profile
-        # in fact, merge is currently not used elsewhere
         return false if merge && !read(force: false)
 
         if Yast::Stage.cont
@@ -176,6 +175,7 @@ module Y2Firewall
       # stage. Exceptions are installation over network (ssh / vnc) with second stage
       # enabled which requires more careful approach
       def import_first_stage(merge = !Yast::Mode.config)
+        log.info("Firewall: importing part of the profile which can be processed in first stage")
         # Obtains the default from the control file (settings) if not present.
         start_firewall_on_target if !need_second_stage_run?
 
@@ -189,6 +189,7 @@ module Y2Firewall
       #
       # Intended for finishing setup of exceptional cases. @see import_first_stage
       def import_second_stage
+        log.info("Firewall: second stage cleanup")
         true
       end
 

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -203,15 +203,15 @@ module Y2Firewall
         # 3) firewall was configured (somehow) and started via AY profile
         remote_installer = Linuxrc.usessh || Linuxrc.vnc
         second_stage_required = self.class.profile.fetch("second_stage", false)
-        firewall_started = self.class.profile.fetch("enable_firewall", settings.enable_firewall)
+        firewall_started = firewall_profile.fetch("enable_firewall", settings.enable_firewall)
 
         remote_installer && second_stage_required && firewall_started
       end
 
       # Configures firewall service to run on target according to AY profile and product defaults
       def start_firewall_on_target
-        enable if self.class.profile.fetch("enable_firewall", settings.enable_firewall)
-        start if self.class.profile.fetch("start_firewall", false)
+        enable if firewall_profile.fetch("enable_firewall", settings.enable_firewall)
+        start if firewall_profile.fetch("start_firewall", false)
       end
 
       # Read the minimal configuration from firewalld, w/o dropping available configuration
@@ -296,6 +296,12 @@ module Y2Firewall
       # @return [Y2Firewall::ProposalSettings]
       def settings
         ProposalSettings.instance
+      end
+
+      # @return [Hash<String, any>] firewall section of the profile
+      def firewall_profile
+        return {} if !self.class.profile
+        self.class.profile.fetch("firewall", {})
       end
 
       # Set that the firewall has to be enabled when writing

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -31,6 +31,7 @@ require "installation/auto_client"
 Yast.import "Mode"
 Yast.import "Stage"
 Yast.import "AutoInstall"
+Yast.import "AutoinstFunctions"
 
 module Y2Firewall
   module Clients
@@ -208,7 +209,7 @@ module Y2Firewall
         # 3) firewall was configured (somehow) and started via AY profile we can expect that
         # ssh / vnc port can be blocked.
         remote_installer = Yast::Linuxrc.usessh || Yast::Linuxrc.vnc
-        second_stage_required = !!self.class.profile.dig("general", "mode", "second_stage")
+        second_stage_required = Yast::AutoinstFunctions.second_stage_required?
         firewall_enabled = self.class.profile.fetch("enable_firewall", settings.enable_firewall)
 
         remote_installer && second_stage_required && firewall_enabled

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -90,7 +90,7 @@ module Y2Firewall
           # stage is enabled and installation runs over network (ssh / vnc)
           import_second_stage
         else
-          import_first_stage(merge)
+          import_first_stage
         end
       end
 
@@ -174,7 +174,7 @@ module Y2Firewall
       # Except a few edge cases complete firewall configuration should be done in first
       # stage. Exceptions are installation over network (ssh / vnc) with second stage
       # enabled which requires more careful approach
-      def import_first_stage(merge = !Yast::Mode.config)
+      def import_first_stage
         log.info("Firewall: importing part of the profile which can be processed in first stage")
         # Obtains the default from the control file (settings) if not present.
         start_firewall_on_target if !need_second_stage_run?
@@ -277,10 +277,10 @@ module Y2Firewall
           start? ? firewalld.start : firewalld.stop
         else
           Yast::Execute.on_target(
-            "/usr/bin/systemctl", enable? ? "enable": "disable", "firewalld"
+            "/usr/bin/systemctl", enable? ? "enable" : "disable", "firewalld"
           )
           Yast::Execute.on_target(
-            "/usr/bin/systemctl", start? ? "start": "stop", "firewalld"
+            "/usr/bin/systemctl", start? ? "start" : "stop", "firewalld"
           )
         end
       end

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -262,9 +262,20 @@ module Y2Firewall
 
       # Depending on the profile it activates or deactivates the firewalld
       # service
+      #
+      # Note: it always activates the service on the target
       def activate_service
-        enable? ? firewalld.enable! : firewalld.disable!
-        start? ? firewalld.start : firewalld.stop
+        if !Yast::Stage.initial
+          enable? ? firewalld.enable! : firewalld.disable!
+          start? ? firewalld.start : firewalld.stop
+        else
+          Yast::Execute.on_target(
+            "/usr/bin/systemctl", enable? ? "enable": "disable", "firewalld"
+          )
+          Yast::Execute.on_target(
+            "/usr/bin/systemctl", start? ? "start": "stop", "firewalld"
+          )
+        end
       end
 
       # Return a firewall autoyast object

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -189,8 +189,13 @@ module Y2Firewall
       #
       # Intended for finishing setup of exceptional cases. @see import_first_stage
       def import_second_stage
-        log.info("Firewall: second stage cleanup")
-        true
+        return if !need_second_stage_run?
+
+        log.info("Firewall: second stage finish script")
+
+        # enable/disable firewall according to the profile. In exceptional case it
+        # cannot be done in the first stage
+        start_firewall_on_target
       end
 
       # Checks whether we need to run second stage handling
@@ -200,12 +205,13 @@ module Y2Firewall
         # We have a problem when
         # 1) running remote installation
         # 2) second stage was requested
-        # 3) firewall was configured (somehow) and started via AY profile
+        # 3) firewall was configured (somehow) and started via AY profile we can expect that
+        # ssh / vnc port can be blocked.
         remote_installer = Linuxrc.usessh || Linuxrc.vnc
         second_stage_required = self.class.profile.fetch("second_stage", false)
-        firewall_started = firewall_profile.fetch("enable_firewall", settings.enable_firewall)
+        firewall_enabled = firewall_profile.fetch("enable_firewall", settings.enable_firewall)
 
-        remote_installer && second_stage_required && firewall_started
+        remote_installer && second_stage_required && firewall_enabled
       end
 
       # Configures firewall service to run on target according to AY profile and product defaults

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -207,8 +207,8 @@ module Y2Firewall
         # 2) second stage was requested
         # 3) firewall was configured (somehow) and started via AY profile we can expect that
         # ssh / vnc port can be blocked.
-        remote_installer = Linuxrc.usessh || Linuxrc.vnc
-        second_stage_required = self.class.profile.fetch("second_stage", false)
+        remote_installer = Yast::Linuxrc.usessh || Yast::Linuxrc.vnc
+        second_stage_required = !!self.class.profile.dig("general", "mode", "second_stage")
         firewall_enabled = firewall_profile.fetch("enable_firewall", settings.enable_firewall)
 
         remote_installer && second_stage_required && firewall_enabled

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -81,7 +81,7 @@ module Y2Firewall
       #
       # @param profile [Hash] firewall profile section to be imported
       # @return [Boolean]
-      def import(profile, merge = !Yast::Mode.config)
+      def import(profile, merge = !Yast::Mode.config || !Yast::Mode.auto)
         self.class.profile = profile
         return false if merge && !read(force: false)
 

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -209,15 +209,15 @@ module Y2Firewall
         # ssh / vnc port can be blocked.
         remote_installer = Yast::Linuxrc.usessh || Yast::Linuxrc.vnc
         second_stage_required = !!self.class.profile.dig("general", "mode", "second_stage")
-        firewall_enabled = firewall_profile.fetch("enable_firewall", settings.enable_firewall)
+        firewall_enabled = self.class.profile.fetch("enable_firewall", settings.enable_firewall)
 
         remote_installer && second_stage_required && firewall_enabled
       end
 
       # Configures firewall service to run on target according to AY profile and product defaults
       def start_firewall_on_target
-        enable if firewall_profile.fetch("enable_firewall", settings.enable_firewall)
-        start if firewall_profile.fetch("start_firewall", false)
+        enable if self.class.profile.fetch("enable_firewall", settings.enable_firewall)
+        start if self.class.profile.fetch("start_firewall", false)
       end
 
       # Read the minimal configuration from firewalld, w/o dropping available configuration
@@ -302,12 +302,6 @@ module Y2Firewall
       # @return [Y2Firewall::ProposalSettings]
       def settings
         ProposalSettings.instance
-      end
-
-      # @return [Hash<String, any>] firewall section of the profile
-      def firewall_profile
-        return {} if !self.class.profile
-        self.class.profile.fetch("firewall", {})
       end
 
       # Set that the firewall has to be enabled when writing

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -59,9 +59,9 @@ module Y2Firewall
       end
 
       def write
-        if Mode.autoinst || Mode.autoupgrade
+        if Yast::Mode.autoinst || Yast::Mode.autoupgrade
           log.info("Firewall: running configuration according to the AY profile")
-          configure_by_profile
+          Y2Firewall::Clients::Auto.new.write
         else
           configure_by_proposals
         end
@@ -74,26 +74,6 @@ module Y2Firewall
         Service.Enable("sshd") if @settings.enable_sshd
         configure_firewall if @firewalld.installed?
         true
-      end
-
-      # In autoyast installation configures the target according to the profile
-      def configure_by_profile
-        Yast.import "Profile"
-
-        if Mode.autoupgrade
-          # This is approach taken from networking. In general, networking and firewall configuration
-          # can be fine tuned for proper run (including access to installation media) to risk its
-          # modification.
-          log.info("Firewall: running in auto upgrade mode, do not touch firewall configuration")
-          return true
-        end
-
-        ay_profile = Profile.current
-        raise "Invalid / non-existing AutoYast profile" if ay_profile.nil? || ay_profile.empty?
-
-        # Lets reuse client we already have
-        ay_client = Clients::Auto.new
-        ay_client.import(ay_profile) && ay_client.write
       end
 
       # Modifies the configuration of the firewall according to the current

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -93,8 +93,7 @@ module Y2Firewall
 
         # Lets reuse client we already have
         ay_client = Clients::Auto.new
-        ay_client.import(ay_profile)
-        ay_client.write
+        ay_client.import(ay_profile) && ay_client.write
       end
 
       # Modifies the configuration of the firewall according to the current

--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -35,6 +35,7 @@ describe Y2Firewall::Clients::Auto do
     allow(firewalld).to receive(:read)
     allow(firewalld).to receive(:installed?).and_return(installed)
     allow(subject).to receive(:autoyast).and_return(autoyast)
+    allow(Yast::AutoinstFunctions).to receive(:second_stage_required?).and_return(false)
     allow_any_instance_of(Y2Firewall::Firewalld::Api).to receive(:running?).and_return(false)
   end
 

--- a/test/lib/y2firewall/clients/installation_finish_test.rb
+++ b/test/lib/y2firewall/clients/installation_finish_test.rb
@@ -8,6 +8,7 @@ Yast.import "Service"
 describe Y2Firewall::Clients::InstallationFinish do
   before do
     allow_any_instance_of(Y2Firewall::Firewalld::Api).to receive(:running?).and_return(false)
+    allow(Yast::AutoinstFunctions).to receive(:second_stage_required?).and_return(false)
   end
 
   let(:proposal_settings) { Y2Firewall::ProposalSettings.instance }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,7 @@ end
 
 # stub classes from other modules to speed up a build
 stub_module("AutoInstall")
+stub_module("AutoinstFunctions")
 # rubocop:disable Style/SingleLineMethods
 # rubocop:disable Style/MethodName
 stub_module("UsersSimple", Class.new { def self.GetRootPassword; "secret"; end })


### PR DESCRIPTION
## Problem ##

We want to run firewall configuration in the fist stage of installer. However, there is problem when installing over ssh / vnc - we don't want to shoot into own leg in such case.

## Solution ##

Uses https://github.com/yast/yast-autoinstallation/pull/653 which loads the firewall client in the first stage. The configuration is completely done during the first stage with one exception. When running over ssh / vnc enabling firewall is postponed to the second stage

## Tests ##

Manual, beside others:
* configure firewall rules & firewall is enabled after installation
* configure firewall rules & firewall is disabled after installation
* configure firewall rules & firewall is enabled after installation, installation over ssh
* configure firewall rules & firewall is disabled after installation, installation over ssh

TBD:
upload testsuite