### PR TITLE
Only export modified zones when asked for export a reduced profile

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 23 15:55:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- AutoYaST: Only export modified zones when it is asked to export a
+  reduced profile. (bsc#1171356)
+- 4.3.2
+
+-------------------------------------------------------------------
 Thu May  7 15:22:56 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Cleanup/improve issue handling (bsc#1171335).

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST
@@ -28,13 +28,13 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 4.2.2
-# AutoYaST issue report
-BuildRequires:  yast2 >= 4.3.2
+# Y2Firewall::Firewalld#modified_from_default
+BuildRequires:  yast2 >= 4.3.16
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
-# AutoYaST issue report
-Requires:       yast2 >= 4.3.2
+# Y2Firewall::Firewalld#modified_from_default
+Requires:       yast2 >= 4.3.16
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 # ButtonBox widget

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -29,12 +29,12 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 4.2.2
 # Y2Firewall::Firewalld#modified_from_default
-BuildRequires:  yast2 >= 4.3.16
+BuildRequires:  yast2 >= 4.3.17
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
 # Y2Firewall::Firewalld#modified_from_default
-Requires:       yast2 >= 4.3.16
+Requires:       yast2 >= 4.3.17
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 # ButtonBox widget

--- a/src/lib/y2firewall/autoyast.rb
+++ b/src/lib/y2firewall/autoyast.rb
@@ -62,7 +62,7 @@ module Y2Firewall
     def zones_to_export(target)
       return firewalld.modified_from_default("zones") if target == "compact"
 
-      firewalld.current_zone_names
+      firewalld.zones.map(&:name)
     end
 
     def export_zones(target)

--- a/src/lib/y2firewall/autoyast.rb
+++ b/src/lib/y2firewall/autoyast.rb
@@ -45,7 +45,7 @@ module Y2Firewall
     # Return a map with current firewalld settings.
     #
     # @return [Hash] dump firewalld settings
-    def export
+    def export(target: :default)
       return {} unless firewalld.installed?
 
       {
@@ -53,11 +53,23 @@ module Y2Firewall
         "start_firewall"     => firewalld.running?,
         "default_zone"       => firewalld.default_zone,
         "log_denied_packets" => firewalld.log_denied_packets,
-        "zones"              => firewalld.zones.map { |z| export_zone(z) }
+        "zones"              => export_zones(target.to_s)
       }
     end
 
   private
+
+    def zones_to_export(target)
+      return firewalld.modified_from_default("zones") if target == "compact"
+
+      firewalld.current_zone_names
+    end
+
+    def export_zones(target)
+      zones = zones_to_export(target)
+
+      firewalld.zones.select { |z| zones.include?(z.name) }.map { |z| export_zone(z) }
+    end
 
     def export_zone(zone)
       (zone.attributes + zone.relations)

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -93,9 +93,11 @@ module Y2Firewall
 
       # Export the current firewalld configuration
       #
+      # @param target [Symbol] Control how much information should be exported
+      #   (e.g., :default or :compact).
       # @return [Hash] with the current firewalld configuration
-      def export
-        autoyast.export
+      def export(target:)
+        autoyast.export(target: target)
       end
 
       # Reset the current firewalld configuration.
@@ -123,6 +125,7 @@ module Y2Firewall
       # it again.
       def write
         return false if !firewalld.installed?
+
         import_if_needed
         return false unless imported?
 

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -96,7 +96,7 @@ module Y2Firewall
       # @param target [Symbol] Control how much information should be exported
       #   (e.g., :default or :compact).
       # @return [Hash] with the current firewalld configuration
-      def export(target:)
+      def export(target: :default)
         autoyast.export(target: target)
       end
 

--- a/test/lib/y2firewall/autoyast_test.rb
+++ b/test/lib/y2firewall/autoyast_test.rb
@@ -86,6 +86,7 @@ describe Y2Firewall::Autoyast do
       allow(firewalld).to receive("running?").and_return true
       allow(firewalld).to receive("enabled?").and_return false
       allow(firewalld).to receive("installed?").and_return true
+      allow(firewalld).to receive(:modified_from_default).with("zones").and_return(["dmz"])
       firewalld.read
     end
 
@@ -108,6 +109,15 @@ describe Y2Firewall::Autoyast do
     it "returned hash is valid for later import" do
       config = subject.export
       expect { subject.import(config) }.to_not raise_error
+    end
+
+    context "when 'compact' export is wanted" do
+      it "exports only modified zones" do
+        config = subject.export(target: "compact")
+
+        expect(config["zones"].size).to eq(1)
+        expect(config["zones"].first["name"]) == "dmz"
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

When the user ask about a reduced profile we export all the available zones even if not modified from the default values.

- https://trello.com/c/bLXXJXbk/1904-5-reduce-firewall-section-size

## Solution

Honor the `target` argument exporting only zones which have been modified from the defaults.

It requires yast/yast-yast2#1083

## Tests

- Tested manually
- Added unit test