### PR TITLE
AutoYaST: Write the proposal settings when no firewall section is defined

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 30 11:47:21 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- AutoYaST: When no firewall section is defined, write the service
+  settings according to the proposal (bsc#1178050)
+- 4.3.9
+
+-------------------------------------------------------------------
 Thu Oct 22 20:44:20 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not warn user about ssh key only authentication when

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.3.8
+Version:        4.3.9
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/clients/installation_finish.rb
+++ b/src/lib/y2firewall/clients/installation_finish.rb
@@ -81,8 +81,6 @@ module Y2Firewall
       # Convenience method to enable / disable the firewalld service depending
       # on the proposal settings
       def configure_firewall_service
-        # do not run in autoyast as it is done in second stage (bsc#1177778)
-        return if Yast::Mode.auto
         # and also only installation, not upgrade one. NOTE: installation mode include auto
         return unless Yast::Mode.installation
 


### PR DESCRIPTION
## Problem

When there is no firewall section defined in the profile we should apply the proposal one. This is not the case anymore since (https://bugzilla.suse.com/show_bug.cgi?id=1177778)

- https://bugzilla.suse.com/show_bug.cgi?id=1178050

## Solution

If the section is not provided we will write the configuration according to the proposal one.