### PR TITLE
Adapt unit test to recent changes in Yast::Report and Yast2::Popup

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 12 14:31:50 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893)
+- 4.3.10
+
+-------------------------------------------------------------------
 Fri Oct 30 11:47:21 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: When no firewall section is defined, write the service

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/test/lib/y2firewall/clients/installation_finish_test.rb
+++ b/test/lib/y2firewall/clients/installation_finish_test.rb
@@ -33,6 +33,7 @@ describe Y2Firewall::Clients::InstallationFinish do
       allow(proposal_settings).to receive(:enable_sshd).and_return(enable_sshd)
       allow(firewalld).to receive(:installed?).and_return(installed)
       allow(proposal_settings).to receive(:open_ssh).and_return(false)
+      allow(subject).to receive(:configure_firewall)
     end
 
     it "enables the sshd service if enabled in the proposal" do

--- a/test/lib/y2firewall/importer_strategies/suse_firewall_test.rb
+++ b/test/lib/y2firewall/importer_strategies/suse_firewall_test.rb
@@ -67,6 +67,7 @@ describe Y2Firewall::ImporterStrategies::SuseFirewall do
 
     context "when the profile is not empty" do
       before do
+        allow(Yast::Report).to receive(:Warning).with(/profile in use is based on SuSEFirewall2/)
         subject.import
       end
 

--- a/test/lib/y2firewall/widgets/zone_test.rb
+++ b/test/lib/y2firewall/widgets/zone_test.rb
@@ -24,18 +24,30 @@ require "cwm/rspec"
 require "y2firewall/widgets/zone"
 
 describe Y2Firewall::Dialogs::NameWidget do
+  before do
+    allow(Yast::Report).to receive(:Error).with(/provide a valid alphanumeric name/)
+  end
+
   subject { described_class.new(double(name: "test")) }
 
   include_examples "CWM::AbstractWidget"
 end
 
 describe Y2Firewall::Dialogs::ShortWidget do
+  before do
+    allow(Yast::Report).to receive(:Error).with(/provide a short name/)
+  end
+
   subject { described_class.new(double(short: "test")) }
 
   include_examples "CWM::AbstractWidget"
 end
 
 describe Y2Firewall::Dialogs::DescriptionWidget do
+  before do
+    allow(Yast::Report).to receive(:Error).with(/provide a description/)
+  end
+
   subject { described_class.new(double(description: "test")) }
 
   include_examples "CWM::AbstractWidget"


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.