### PR TITLE
[SLE-15-SP2] Fix test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ end
 # stub classes from other modules to speed up a build
 # rubocop:disable Style/SingleLineMethods
 # rubocop:disable Style/MethodName
-stub_module("AutoInstall", Class.new { def issues_list; []; end })
+stub_module("AutoInstall", Class.new { def self.issues_list; []; end })
 stub_module("UsersSimple", Class.new { def self.GetRootPassword; "secret"; end })
 # rubocop:enable Style/SingleLineMethods
 # rubocop:enable Style/MethodName


### PR DESCRIPTION
Related to #144, it fixes the `stub_module` call in the _test\_helper_ file for the `AutoInstall` module, avoiding to get below error 

```
NameError:
   component cannot import namespace 'AutoInstall'
 # ./src/lib/y2firewall/clients/auto.rb:31:in `<top (required)>'
 # ./test/lib/y2firewall/clients/auto_test.rb:24:in `<top (required)>'
```

No bump version required.