### PR TITLE
[SLE-15-SP2] Fix SELinux typo

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  1 15:39:46 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Use the correct SELinux abbreviation (related to jsc#SLE-17427).
+- 4.2.7
+
+-------------------------------------------------------------------
 Thu Feb  4 09:14:13 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Add to firewall/security proposal option to setup selinux if

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/clients/proposal.rb
+++ b/src/lib/y2firewall/clients/proposal.rb
@@ -230,7 +230,7 @@ module Y2Firewall
           @settings.selinux_config.needed_patterns)
 
         _(
-          "Selinux Default Mode is %s"
+          "SELinux Default Mode is %s"
         ) % @settings.selinux_config.mode.to_human_string
       end
     end


### PR DESCRIPTION
The correct and common abbreviation for [Security-Enhanced Linux](https://en.wikipedia.org/wiki/Security-Enhanced_Linux) is `SELinux`, not  `Selinux`. So, let's use the right one :)


---

Related to https://github.com/yast/yast-firewall/pull/144