### PR TITLE
Avoid "No widget..." error messages

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 29 10:14:23 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not display "No widget..." error messages when opening
+  a firewall zone widget (bsc#1184115).
+- 4.3.11
+
+-------------------------------------------------------------------
 Fri Feb 12 14:31:50 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -28,13 +28,13 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 4.2.2
-# Y2Firewall::Firewalld#modified_from_default
-BuildRequires:  yast2 >= 4.3.17
+# CWM::AbstractWidget#displayed?
+BuildRequires:  yast2 >= 4.3.60
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 
-# Y2Firewall::Firewalld#modified_from_default
-Requires:       yast2 >= 4.3.17
+# CWM::AbstractWidget#displayed?
+Requires:       yast2 >= 4.3.60
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 # ButtonBox widget

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/widgets/services_table.rb
+++ b/src/lib/y2firewall/widgets/services_table.rb
@@ -71,7 +71,7 @@ module Y2Firewall
       def services=(services)
         old_services = @services
         @services = services
-        change_items(items)
+        change_items(items) if displayed?
 
         return if Yast::UI.TextMode
 


### PR DESCRIPTION
This PR relies on https://github.com/yast/yast-yast2/pull/1149 to avoid logging the annoying "No widget..." error messages when opening a firewall zone tab.

[bsc#1184115](https://bugzilla.suse.com/show_bug.cgi?id=1184115)
