### PR TITLE
Fix test

### DIFF
--- a/test/lib/y2firewall/clients/auto_test.rb
+++ b/test/lib/y2firewall/clients/auto_test.rb
@@ -1,23 +1,23 @@
 #!/usr/bin/env rspec
 
-# ------------------------------------------------------------------------------
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
+# All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of version 2 of the GNU General Public License as published by the
-# Free Software Foundation.
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
 #
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, contact SUSE.
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
 #
-# To contact SUSE about this file by physical or electronic mail, you may find
-# current contact information at www.suse.com.
-# ------------------------------------------------------------------------------
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require_relative "../../../test_helper"
 require "y2firewall/dialogs/main"
@@ -36,7 +36,11 @@ describe Y2Firewall::Clients::Auto do
     allow(firewalld).to receive(:installed?).and_return(installed)
     allow(subject).to receive(:autoyast).and_return(autoyast)
     allow_any_instance_of(Y2Firewall::Firewalld::Api).to receive(:running?).and_return(false)
+
+    allow(subject).to receive(:settings).and_return(security_settings)
   end
+
+  let(:security_settings) { double("::Installation::SecuritySettings", enable_firewall: false) }
 
   describe "#summary" do
     let(:installed) { false }

--- a/test/lib/y2firewall/widgets/proposal_test.rb
+++ b/test/lib/y2firewall/widgets/proposal_test.rb
@@ -1,35 +1,32 @@
 #!/usr/bin/env rspec
 
-# ------------------------------------------------------------------------------
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
+# All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of version 2 of the GNU General Public License as published by the
-# Free Software Foundation.
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
 #
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, contact SUSE.
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
 #
-# To contact SUSE about this file by physical or electronic mail, you may find
-# current contact information at www.suse.com.
-# ------------------------------------------------------------------------------
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require_relative "../../../test_helper.rb"
 require "cwm/rspec"
 require "y2firewall/widgets/proposal"
-require "installation/security_settings"
 
 describe Y2Firewall::Widgets do
   let(:proposal_settings) do
-    instance_double(
-      ::Installation::SecuritySettings, enable_firewall: true, enable_sshd: true,
-        open_ssh: true, open_vnc: true
-    )
+    double("::Installation::SecuritySettings", enable_firewall: true, enable_sshd: true,
+      open_ssh: true, open_vnc: true)
   end
 
   describe Y2Firewall::Widgets::FirewallSSHProposal do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,21 @@ ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 require "yast"
 require "yast/rspec"
 
+LIBS_TO_SKIP = ["installation/security_settings"].freeze
+
+# Hack to avoid to require some files
+#
+# This is here to avoid a cyclic dependency with yast-installation at build time.
+# The package yast-firewall does not include a BuildRequires for yast-installation, so the require
+# for files defined by that package must be avoided.
+module Kernel
+  alias_method :old_require, :require
+
+  def require(path)
+    old_require(path) unless LIBS_TO_SKIP.include?(path)
+  end
+end
+
 # stub module to prevent its Import
 # Useful for modules from different yast packages, to avoid build dependencies
 def stub_module(name, fake_class = nil)


### PR DESCRIPTION
## Problem

There is a failure requiring *installation/security_settings* after merging https://github.com/yast/yast-firewall/pull/150. But *yast2-installation* cannot be added as build dependency because *yast2-installation* already depends on *yast2-firewall*.

* https://ci.opensuse.org/job/yast-yast-firewall-master/47/console

## Solution

Mock `Installation::SecuritySettings` in order to avoid dependency of *yast2-installation*.
