### PR TITLE
Service state

### DIFF
--- a/package/yast2-firewall.changes
+++ b/package/yast2-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct 31 16:42:54 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- In case of autoinstallation keep the firewall service state in
+  the Installation::SecuritySettings for not conflicting with the
+  proposal (bsc#1216615)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-firewall.spec
+++ b/package/yast2-firewall.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-firewall
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Firewall Configuration
 Group:          System/YaST

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -83,6 +83,7 @@ module Y2Firewall
         # by the AutoYaST confirm dialog.
         update_service_state(profile)
         return false if merge && !read(force: false)
+
         start if profile.fetch("start_firewall", false)
         autoyast.import(profile)
         check_profile_for_errors
@@ -250,7 +251,9 @@ module Y2Firewall
         state = profile.fetch("enable_firewall", settings.enable_firewall)
 
         log.info("Firewall should be enabled: #{state}")
-        state ? settings.enable_firewall! : settings.disable_firewall! if Yast::Mode.auto
+        if Yast::Mode.auto
+          state ? settings.enable_firewall! : settings.disable_firewall!
+        end
         state
       end
 

--- a/src/lib/y2firewall/clients/auto.rb
+++ b/src/lib/y2firewall/clients/auto.rb
@@ -79,10 +79,10 @@ module Y2Firewall
       # @return [Boolean]
       def import(profile, merge = !Yast::Mode.config)
         self.class.profile = profile
+        # It does not need to be merged with current config but could be modified
+        # by the AutoYaST confirm dialog.
+        update_service_state(profile)
         return false if merge && !read(force: false)
-
-        # Obtains the default from the control file (settings) if not present.
-        enable if profile.fetch("enable_firewall", settings.enable_firewall)
         start if profile.fetch("start_firewall", false)
         autoyast.import(profile)
         check_profile_for_errors
@@ -240,16 +240,25 @@ module Y2Firewall
         ::Installation::SecuritySettings.instance
       end
 
-      # Set that the firewall has to be enabled when writing
-      def enable
-        self.class.enable = true
+      # It sets which should be the firewalld service state according to the profile
+      # or to the product defaults settings
+      #
+      # @param profile [Hash] firewall profile section to be imported
+      def update_service_state(profile)
+        return unless self.class.enable.nil?
+
+        state = profile.fetch("enable_firewall", settings.enable_firewall)
+
+        log.info("Firewall should be enabled: #{state}")
+        state ? settings.enable_firewall! : settings.disable_firewall! if Yast::Mode.auto
+        state
       end
 
       # Whether the firewalld service has to be enable or disable when writing
       #
       # @return [Boolean] true if has to be enabled; false otherwise
       def enable?
-        !!self.class.enable
+        !!(Yast::Mode.auto ? settings.enable_firewall : self.class.enable)
       end
 
       # Set that the firewall has to be started when writing


### PR DESCRIPTION
## Problem

The settings imported from the profile are applied at the end of the installation but it does not respect changes that could be introduced by the proposal which is the case of the confirm dialog.

- https://bugzilla.suse.com/show_bug.cgi?id=1216615

## Solution

Import the settings from the profile storing them in the **Installation::SecuritySettings** in case of an autoinstallation.

## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

